### PR TITLE
test(validation): add finite-line truncation coverage

### DIFF
--- a/Sources/PretextValidation/main.swift
+++ b/Sources/PretextValidation/main.swift
@@ -319,6 +319,35 @@ struct ValidationSuite {
             try expect(packet.lines.last?.isTruncated == true, "expected final visible line to carry truncation state")
         }
 
+        execute("single-line-tail-truncation-exposes-visible-range") {
+            let prepared = engine.prepare(
+                fixtureText("Single-line cards should expose their visible source span when the core engine truncates the tail."),
+                sourceID: PreparedTextSourceID("validation-line-limit-single"),
+                options: PreparedTextOptions(whiteSpaceMode: .uikitLiteral)
+            )
+
+            let packet = engine.layoutPacket(
+                prepared,
+                maxWidth: 108,
+                lineHeight: prepared.defaultLineHeight,
+                env: .default,
+                options: PreparedTextLayoutOptions(
+                    maximumNumberOfLines: 1,
+                    lineBreakMode: .truncateTail,
+                    lineBreakStrategy: .automatic,
+                    alignment: .natural,
+                    layoutDirection: .leftToRight
+                )
+            )
+
+            try expect(packet.lines.count == 1, "expected exactly one visible line")
+            try expect(packet.result.isTruncated, "expected single-line layout to report truncation")
+            try expect(packet.result.stoppedEarlyAtMaximumNumberOfLines, "expected single-line layout to stop early")
+            try expect(packet.lines.first?.isTruncated == true, "expected visible line to carry truncation state")
+            try expect(packet.result.visibleSourceUTF16Ranges.count == 1, "expected a single visible source range for tail truncation")
+            try expect(packet.sourceCoordinateMap.lines.first?.visibleSourceUTF16Ranges.count == 1, "expected source coordinate map to preserve the visible range")
+        }
+
         execute("word-wrap-line-limit-still-reports-hidden-overflow") {
             let prepared = engine.prepare(
                 fixtureText("Word wrapping with a finite line limit should clip overflow without inventing an ellipsis token."),
@@ -343,6 +372,61 @@ struct ValidationSuite {
             try expect(packet.result.isTruncated, "expected finite word-wrap layout to report clipped overflow")
             try expect(packet.lines.first?.isTruncated == true, "expected final visible line to report truncation even without an ellipsis")
             try expect(packet.lines.first?.attributedText.string.contains("…") == false, "word-wrap clipping should not inject ellipsis")
+        }
+
+        execute("url-friendly-line-limit-preserves-structured-breaks") {
+            let prepared = engine.prepare(
+                fixtureText("https://example.com/prepared-layouts/with/a/long/path/that/needs/structured/breaks"),
+                sourceID: PreparedTextSourceID("validation-url-line-limit"),
+                options: PreparedTextOptions(whiteSpaceMode: .uikitLiteral)
+            )
+
+            let packet = engine.layoutPacket(
+                prepared,
+                maxWidth: measure("https://example.com/") + 0.25,
+                lineHeight: prepared.defaultLineHeight,
+                env: .default,
+                options: PreparedTextLayoutOptions(
+                    maximumNumberOfLines: 1,
+                    lineBreakMode: .wordWrap,
+                    lineBreakStrategy: .urlFriendly,
+                    alignment: .natural,
+                    layoutDirection: .leftToRight
+                )
+            )
+
+            try expect(packet.lines.count == 1, "expected exactly one visible url-heavy line")
+            try expect(packet.result.isTruncated, "expected url-heavy finite-line layout to report clipped overflow")
+            try expect(packet.lines.first?.attributedText.string == "https://example.com/", "expected url-friendly strategy to preserve a structured breakpoint")
+            try expect(packet.result.visibleSourceUTF16Ranges.count == 1, "expected visible source range for the structured url prefix")
+        }
+
+        execute("korean-finite-line-truncation-remains-core-owned") {
+            let prepared = engine.prepare(
+                fixtureText("준비된 텍스트 엔진은 반복되는 카드 요약 폭에서도 유한 줄 수와 잘린 범위를 코어 레이아웃 결과로 직접 노출해야 한다."),
+                sourceID: PreparedTextSourceID("validation-korean-line-limit"),
+                options: PreparedTextOptions(whiteSpaceMode: .uikitLiteral)
+            )
+
+            let packet = engine.layoutPacket(
+                prepared,
+                maxWidth: 116,
+                lineHeight: prepared.defaultLineHeight,
+                env: .default,
+                options: PreparedTextLayoutOptions(
+                    maximumNumberOfLines: 2,
+                    lineBreakMode: .truncateTail,
+                    lineBreakStrategy: .cjkImproved,
+                    alignment: .natural,
+                    layoutDirection: .leftToRight
+                )
+            )
+
+            try expect(packet.lines.count == 2, "expected exactly two visible Korean lines")
+            try expect(packet.result.isTruncated, "expected Korean finite-line layout to report truncation")
+            try expect(packet.result.stoppedEarlyAtMaximumNumberOfLines, "expected Korean finite-line layout to stop early")
+            try expect(packet.result.visibleLineCount == 2, "expected visible line count to remain observable")
+            try expect(packet.result.visibleSourceUTF16Ranges.isEmpty == false, "expected visible source ranges for the retained Korean lines")
         }
 
         execute("layout-direction-affects-core-alignment-resolution") {

--- a/docs/ReleaseChecklist.md
+++ b/docs/ReleaseChecklist.md
@@ -29,6 +29,7 @@ swift run PretextBenchmarks
   - semantic checks must pass
   - the stable host gate corpus must keep exact line counts, no divergent strict lines, and `heightDelta <= 1pt`
   - core-owned finite-line / truncation / layout-direction semantic checks must stay green
+  - 1-line truncation, URL-heavy finite-line, and Korean finite-line semantic checks must stay green
 - `swift run PretextBenchmarks`
   - `.build/reports/benchmark-results.md` must regenerate and be non-empty
   - release review should use the default benchmark sample counts, not a reduced local smoke profile

--- a/docs/Validation.md
+++ b/docs/Validation.md
@@ -31,7 +31,10 @@ Report mode is intentionally descriptive. It prints the current host-side compar
 The semantic check section now includes direct engine-level finite-line assertions such as:
 
 - `finite-line-tail-truncation-is-core-owned`
+- `single-line-tail-truncation-exposes-visible-range`
 - `word-wrap-line-limit-still-reports-hidden-overflow`
+- `url-friendly-line-limit-preserves-structured-breaks`
+- `korean-finite-line-truncation-remains-core-owned`
 - `layout-direction-affects-core-alignment-resolution`
 
 ## Host gate


### PR DESCRIPTION
## Summary

This PR closes the remaining Phase 2 audit gap in the release validation path.

The core engine already owned finite-line layout, truncation, line-break strategy, and layout-direction-sensitive alignment semantics after the Phase 2 implementation pass. The remaining issue was narrower: the release-facing validation suite did not explicitly assert three cases that the implementation and XCTest coverage already treated as part of the supported Phase 2 story.

Those missing cases were:

- single-line tail truncation with visible-range exposure
- URL-heavy finite-line layout under the promoted `urlFriendly` line-break strategy
- Korean finite-line truncation sanity under the promoted core layout path

This PR adds executable semantic checks for those cases to the host validation suite and updates the validation/release documentation so the documented Phase 2 gate matches the real repository state.

## Changes

- Added a new host semantic check in [Sources/PretextValidation/main.swift](/Users/ijuhwa/Documents/prepared-text-ios/Sources/PretextValidation/main.swift) for single-line tail truncation.
  - Verifies the core packet path returns exactly one visible line.
  - Verifies `isTruncated == true`.
  - Verifies `stoppedEarlyAtMaximumNumberOfLines == true`.
  - Verifies the visible line itself is marked truncated.
  - Verifies visible source-range metadata is preserved through both `LayoutResult.visibleSourceUTF16Ranges` and `PreparedLayoutPacket.sourceCoordinateMap`.

- Added a new host semantic check in [Sources/PretextValidation/main.swift](/Users/ijuhwa/Documents/prepared-text-ios/Sources/PretextValidation/main.swift) for URL-heavy finite-line layout.
  - Uses a URL-heavy input with `maximumNumberOfLines = 1`.
  - Uses `lineBreakMode = .wordWrap` and `lineBreakStrategy = .urlFriendly`.
  - Verifies the resulting visible line keeps the structured prefix break at `https://example.com/` instead of falling through to a less meaningful split.
  - Verifies the result is still reported as truncated and exposes a visible source range.

- Added a new host semantic check in [Sources/PretextValidation/main.swift](/Users/ijuhwa/Documents/prepared-text-ios/Sources/PretextValidation/main.swift) for supported-script finite-line sanity.
  - Uses a Korean sentence with `maximumNumberOfLines = 2`.
  - Uses `lineBreakMode = .truncateTail` and `lineBreakStrategy = .cjkImproved`.
  - Verifies line count, truncation, early-stop, visible-line observability, and non-empty visible source ranges.

- Updated [docs/Validation.md](/Users/ijuhwa/Documents/prepared-text-ios/docs/Validation.md).
  - The documented semantic check list now includes the new 1-line truncation, URL-heavy finite-line, and Korean finite-line checks.
  - This makes the public validation story match the actual executable validation suite.

- Updated [docs/ReleaseChecklist.md](/Users/ijuhwa/Documents/prepared-text-ios/docs/ReleaseChecklist.md).
  - The release gate expectations now call out that these additional Phase 2 semantic checks must stay green before tagging.
  - This keeps the release checklist aligned with the real repository acceptance bar.

## Testing

Ran the full documented Phase 2 verification path after the validation/doc changes:

- `source scripts/use-local-xcode.sh && swift test`
  - Passed: `57` tests, `0` failures.

- `source scripts/use-local-xcode.sh && ./scripts/run-validation.sh`
  - Passed.
  - Host report stayed at `39 comparisons`, `0 diffs`.
  - New semantic checks passed:
    - `single-line-tail-truncation-exposes-visible-range`
    - `url-friendly-line-limit-preserves-structured-breaks`
    - `korean-finite-line-truncation-remains-core-owned`

- `source scripts/use-local-xcode.sh && ./scripts/run-validation-gate.sh`
  - Passed.
  - Host strict threshold gate remained green with `0` strict diffs and `0.0pt` worst height delta.

- `source scripts/use-local-xcode.sh && ./scripts/run-benchmarks.sh`
  - Passed with default sample counts.
  - Benchmark report regenerated successfully.
  - Finite-line and URL strategy sections remained present and non-empty.

- `source scripts/use-local-xcode.sh && ./scripts/run-ios-demo-tests.sh`
  - Passed: `46` simulator tests, `0` failures.

- `./scripts/check-repo-readiness.sh`
  - Passed.

- `./scripts/check-pr.sh --title "test(validation): close phase 2 semantic audit gaps" --body-file /tmp/prepared-text-ios-pr-phase2-validation.md`
  - Passed.

## Risks and follow-ups

- This PR does not change Phase 2 core layout semantics, cache identity, or UIKit/SwiftUI ownership boundaries.
- The only behavior change is that the release validation path now asserts more of the already-supported Phase 2 surface.
- If any future change regresses 1-line truncation visibility, URL-heavy finite-line behavior, or Korean finite-line truncation semantics, this validation suite will now fail earlier and more explicitly.

## Related issues

- None.
