### PR TITLE
feat(prepared): add link accessibility, attachment lifecycle, and rect helpers

### DIFF
--- a/Apps/PreparedTextDemo/README.md
+++ b/Apps/PreparedTextDemo/README.md
@@ -14,8 +14,9 @@ Its XCTest gate covers the supported simulator baseline subset while the broader
 The current showcase also includes narrow public differentiators that sit on top of the prepared layout engine:
 
 - prepared structure inspection with inline attachment, link, mention, and hashtag content
+- attachment resolver state and multi-link accessibility behavior through `PreparedLabelView`
 - source-coordinate-map-driven visible span inspection
-- circle-obstacle exclusion layout for read-only prepared surfaces
+- circle-obstacle interaction demos for read-only prepared surfaces, with rounded-rect obstacle coverage kept in host validation and benchmark fixtures
 
 ## Open in Xcode
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -148,12 +148,12 @@ zero-arg `Text.prepared()`는 여전히 지원하지 않습니다. SwiftUI `Text
 - `PreparedTextMeasurementOptions` 로 제어하는 public pixel-aligned measurement
 - `PreparedInvalidationCenter` 기반 explicit invalidation
 - `PreparedTextDiagnosticsSnapshot` 기반 public diagnostics
-- `PreparedAttachmentRegistry` 기반 attachment-aware inline prepared layout
+- `PreparedAttachmentResolver`, `PreparedAttachmentRegistry` 기반 attachment-aware inline prepared layout
 - `PreparedTextLayoutOptions` 기반 core-owned finite-line display policy
 - `PreparedTextLineBreakStrategy` 기반 public line-break strategy 선택
 - `PreparedToken`, `PreparedAnnotation`, `PreparedAttachmentSpan` 기반 public prepared-structure inspection
-- `PreparedTextSourceCoordinateMap` 기반 practical source/display coordinate conversion
-- `PreparedTextObstacleLayouter`, `PreparedObstacle` 기반 reusable circle-obstacle layout
+- `PreparedTextSourceCoordinateMap` 기반 practical source/display coordinate conversion과 rect query
+- `PreparedTextObstacleLayouter`, `PreparedObstacle` 기반 reusable circle / rounded-rect obstacle layout
 
 예시:
 
@@ -194,6 +194,7 @@ let coordinateMap = packet.sourceCoordinateMap
 let tokens = packet.visibleTokens(in: prepared)
 let annotations = packet.visibleAnnotations(in: prepared)
 let attachmentSpans = packet.visibleAttachmentSpans(in: prepared)
+let linkRects = annotations.first.map { coordinateMap.displayedRects(for: $0) } ?? []
 ```
 
 visual parity가 더 중요하면 exact width를 유지하세요.
@@ -215,14 +216,16 @@ Phase 2에서는 core engine이 직접 아래 semantics를 소유합니다.
 
 Phase 3에서는 이 ownership model 위에 네 가지 narrow public differentiator를 올립니다.
 
-- `PreparedAttachmentRegistry` 기반 attachment-aware prepared layout
+- `PreparedAttachmentResolver`, `PreparedAttachmentRegistry` 기반 attachment-aware prepared layout
 - `PreparedText.tokens`, `PreparedText.annotations`, `PreparedText.attachmentSpans` 기반 prepared structure inspection
-- `PreparedTextSourceCoordinateMap` 기반 source/display coordinate conversion
-- `PreparedTextObstacleLayouter` 기반 circle-only exclusion layout
+- `PreparedTextSourceCoordinateMap` 기반 source/display coordinate conversion과 visible rect query
+- `PreparedLabelView` 의 multi-link per-element accessibility
+- `PreparedTextObstacleLayouter` 기반 circle / rounded-rect exclusion layout
 
 여기서 attachment 지원이 뜻하는 범위는 다음과 같습니다.
 
 - read-only inline attachment가 실제 metric이 도착하기 전에도 placeholder bounds를 제공할 수 있다
+- `PreparedAttachmentResolver` 가 placeholder / resolved lifecycle을 직접 노출하고, `PreparedAttachmentRegistry` 가 기본 shared adapter로 남는다
 - resolved metrics와 content identity가 prepared layout reuse에 참여한다
 - registry update가 영향을 받은 prepared source ID만 targeted invalidation 할 수 있다
 - Stage 1 renderer는 이 metric을 소비하지만, full async media framework를 제공한다고 주장하지 않는다
@@ -231,17 +234,19 @@ token / annotation surface 역시 의도적으로 좁게 유지합니다.
 
 - link, mention, hashtag, attachment span, prepared word-like span을 deterministic 하게 검사할 수 있다
 - truncation 이후 visible token / annotation filtering은 packet 또는 coordinate map helper로 수행할 수 있다
+- `PreparedTextSourceCoordinateMap.displayedRects(...)` 로 해당 range를 visible rect로 다시 꺼내 interaction, analytics, debug overlay, accessibility scaffolding에 쓸 수 있다
 - editor model, syntax highlighter framework, generalized NLP/entity product로 넓히지 않는다
 
 coordinate mapping도 exactness를 숨기지 않습니다.
 
 - source coordinate space를 보존하는 모드에서는 `.exact`
 - whitespace normalization이 들어가는 모드에서는 `.bestEffort`
-- source UTF-16 range를 displayed span / visible line으로 보내고, 보존 가능한 범위에서 다시 source range로 되돌릴 수 있다
+- source UTF-16 range를 displayed span / visible line / visible rect로 보내고, 보존 가능한 범위에서 다시 source range로 되돌릴 수 있다
+- `PreparedLabelView` 의 multi-link accessibility도 같은 prepared representation geometry를 사용하고, 안전하게 분리할 수 없을 때만 container-level custom action fallback을 사용한다
 
 obstacle-aware layout도 명확히 narrow 합니다.
 
-- `PreparedTextObstacleLayouter` 는 repeated-width read-only text를 circle exclusion zone 주변에 흐르게 하는 용도입니다
+- `PreparedTextObstacleLayouter` 는 repeated-width read-only text를 circle 또는 rounded-rect exclusion zone 주변에 흐르게 하는 용도입니다
 - avatar avoidance, decorative card surface, editorial accent 같은 케이스에 맞습니다
 - arbitrary publication layout, scene-graph composition, browser-grade flowing text를 목표로 하지 않습니다
 

--- a/README.md
+++ b/README.md
@@ -149,12 +149,12 @@ It now behaves like a reusable layout engine for read-only repeated-width surfac
 - public pixel-aligned measurement through `PreparedTextMeasurementOptions`
 - explicit invalidation through `PreparedInvalidationCenter`
 - public diagnostics through `PreparedTextDiagnosticsSnapshot`
-- attachment-aware inline prepared layout through `PreparedAttachmentRegistry`
+- attachment-aware inline prepared layout through `PreparedAttachmentResolver` and `PreparedAttachmentRegistry`
 - core-owned finite-line display policy through `PreparedTextLayoutOptions`
 - public line-break strategy selection through `PreparedTextLineBreakStrategy`
 - public prepared-structure inspection through `PreparedToken`, `PreparedAnnotation`, and `PreparedAttachmentSpan`
-- practical source/display conversion through `PreparedTextSourceCoordinateMap`
-- reusable circle-obstacle layout through `PreparedTextObstacleLayouter` and `PreparedObstacle`
+- practical source/display conversion and rect queries through `PreparedTextSourceCoordinateMap`
+- reusable circle / rounded-rect obstacle layout through `PreparedTextObstacleLayouter` and `PreparedObstacle`
 
 Example:
 
@@ -195,6 +195,7 @@ let coordinateMap = packet.sourceCoordinateMap
 let tokens = packet.visibleTokens(in: prepared)
 let annotations = packet.visibleAnnotations(in: prepared)
 let attachmentSpans = packet.visibleAttachmentSpans(in: prepared)
+let linkRects = annotations.first.map { coordinateMap.displayedRects(for: $0) } ?? []
 ```
 
 Use exact widths when visual parity matters more than cache reuse.
@@ -216,14 +217,16 @@ That means a 2-line tail-truncated feed card now has its own prepared layout key
 
 Phase 3 builds on that ownership model with four narrow public differentiators:
 
-- attachment-aware prepared layout through placeholder metrics, resolved metrics, attachment identity, and targeted invalidation in `PreparedAttachmentRegistry`
+- attachment-aware prepared layout through placeholder metrics, resolved metrics, attachment identity, and targeted invalidation in `PreparedAttachmentResolver` / `PreparedAttachmentRegistry`
 - prepared token and annotation inspection through `PreparedText.tokens`, `PreparedText.annotations`, and `PreparedText.attachmentSpans`
-- source/display coordinate conversion through `PreparedTextSourceCoordinateMap`
-- circle-only exclusion layout through `PreparedTextObstacleLayouter`
+- source/display coordinate conversion and visible rect queries through `PreparedTextSourceCoordinateMap`
+- per-link accessibility elements in `PreparedLabelView` when multiple visible links remain on screen
+- circle and rounded-rect exclusion layout through `PreparedTextObstacleLayouter`
 
 Attachment support now means:
 
 - inline read-only attachments can contribute placeholder bounds before real metrics are available
+- `PreparedAttachmentResolver` exposes the placeholder vs resolved lifecycle directly, while `PreparedAttachmentRegistry` remains the default shared adapter
 - resolved metrics and content identity participate in prepared layout reuse
 - registry updates can target only the affected prepared source IDs for invalidation
 - Stage 1 renderers consume those resolved metrics without pretending to be a full async media framework
@@ -232,17 +235,19 @@ Token and annotation APIs are intentionally narrow:
 
 - links, mentions, hashtags, attachment spans, and prepared word-like spans can be inspected deterministically
 - visible token and annotation filtering works through the packet or coordinate map after truncation
+- `PreparedTextSourceCoordinateMap.displayedRects(...)` can turn those ranges back into visible rects for interaction, analytics, debug overlays, and accessibility scaffolding
 - the package still does not become an editor model, syntax highlighter framework, or generalized NLP/entity system
 
 Coordinate mapping is also explicit about exactness:
 
 - coordinate-preserving modes expose `.exact` mapping
 - whitespace-normalizing modes expose `.bestEffort` mapping instead of pretending reverse conversion is perfect
-- packet and map helpers can translate source UTF-16 ranges to displayed spans, visible lines, and back where the prepared representation preserves enough information
+- packet and map helpers can translate source UTF-16 ranges to displayed spans, visible lines, visible rects, and back where the prepared representation preserves enough information
+- `PreparedLabelView` builds its multi-link accessibility geometry from that same prepared representation, and falls back to container-level custom actions only when separate visible elements cannot be formed safely
 
 Obstacle-aware layout remains intentionally narrow:
 
-- `PreparedTextObstacleLayouter` is for repeated-width read-only layout around circle exclusion zones
+- `PreparedTextObstacleLayouter` is for repeated-width read-only layout around circle or rounded-rect exclusion zones
 - it fits card, avatar, and decorative avoidance scenarios
 - it does not claim arbitrary publication layout, scene-graph composition, or browser-grade flowing text
 

--- a/Sources/PretextBenchmarks/main.swift
+++ b/Sources/PretextBenchmarks/main.swift
@@ -330,7 +330,7 @@ struct PretextBenchmarkCLI {
                 let tokens = prepared.tokens
                 var matchCount = 0
                 for token in tokens {
-                    matchCount += packet.sourceCoordinateMap.displayedSpans(forSourceUTF16Range: token.sourceUTF16Range).count
+                    matchCount += packet.sourceCoordinateMap.displayedRects(for: token).count
                 }
                 consume(matchCount)
             }
@@ -344,8 +344,8 @@ struct PretextBenchmarkCLI {
         lines.append("")
         lines.append("## Obstacle Layout Sweep")
         lines.append("")
-        lines.append("| Fixture | Sweep Median | Sweep p95 | Rows | Split Rows | Notes |")
-        lines.append("| --- | ---: | ---: | ---: | ---: | --- |")
+        lines.append("| Fixture | Shape | Sweep Median | Sweep p95 | Rows | Split Rows | Notes |")
+        lines.append("| --- | --- | ---: | ---: | ---: | ---: | --- |")
 
         if let obstacleFixture = fixtures.first(where: { $0.name == "token-heavy" }) {
             let textSystem = PreparedTextSystem(
@@ -390,7 +390,51 @@ struct PretextBenchmarkCLI {
                 minimumSpanWidth: 30
             )
             lines.append(
-                "| \(obstacleFixture.name) | \(format(sweep.median)) | \(format(sweep.p95)) | \(sampleResult.rowCount) | \(sampleResult.snapshot.splitRowCount) | circle-only exclusion zones over prepared line walking |"
+                "| \(obstacleFixture.name) | circle | \(format(sweep.median)) | \(format(sweep.p95)) | \(sampleResult.rowCount) | \(sampleResult.snapshot.splitRowCount) | avatar-style circle exclusion over prepared line walking |"
+            )
+
+            let roundedRectSweep = sweepMeasurements(
+                sampleCount: iterations,
+                widths: widths,
+                repetitionsPerSample: sweepRepetitions
+            ) {
+                for width in widths {
+                    let result = layouter.layout(
+                        prepared: prepared,
+                        in: CGRect(x: 0, y: 0, width: width, height: 220),
+                        obstacles: [
+                            PreparedObstacle(
+                                roundedRect: PreparedTextObstacleRoundedRect(
+                                    rect: CGRect(x: width * 0.5, y: 58, width: 84, height: 96),
+                                    cornerRadius: 22
+                                )
+                            ),
+                        ],
+                        lineHeight: obstacleFixture.lineHeight,
+                        obstaclePadding: 12,
+                        minimumSpanWidth: 30
+                    )
+                    consume(result.fragments.count)
+                    consume(result.snapshot.splitRowCount)
+                }
+            }
+            let roundedRectSample = layouter.layout(
+                prepared: prepared,
+                in: CGRect(x: 0, y: 0, width: obstacleFixture.primaryWidth, height: 220),
+                obstacles: [
+                    PreparedObstacle(
+                        roundedRect: PreparedTextObstacleRoundedRect(
+                            rect: CGRect(x: obstacleFixture.primaryWidth * 0.5, y: 58, width: 84, height: 96),
+                            cornerRadius: 22
+                        )
+                    ),
+                ],
+                lineHeight: obstacleFixture.lineHeight,
+                obstaclePadding: 12,
+                minimumSpanWidth: 30
+            )
+            lines.append(
+                "| \(obstacleFixture.name) | rounded-rect | \(format(roundedRectSweep.median)) | \(format(roundedRectSweep.p95)) | \(roundedRectSample.rowCount) | \(roundedRectSample.snapshot.splitRowCount) | narrow panel-style exclusion through `PreparedObstacleShape.roundedRect` |"
             )
         }
 #endif

--- a/Sources/PretextCore/Engine/PreparedTextDisplayLayout.swift
+++ b/Sources/PretextCore/Engine/PreparedTextDisplayLayout.swift
@@ -89,28 +89,65 @@ public struct PreparedTextDisplayedSpan: Hashable, Sendable {
     public var lineIndex: Int
     public var displayUTF16Range: NSRange
     public var sourceUTF16Range: NSRange?
+    public var displayRect: CGRect?
     public var isTruncatedLine: Bool
+    public var isExact: Bool
 
     public init(
         lineIndex: Int,
         displayUTF16Range: NSRange,
         sourceUTF16Range: NSRange?,
-        isTruncatedLine: Bool
+        displayRect: CGRect? = nil,
+        isTruncatedLine: Bool,
+        isExact: Bool = false
     ) {
         self.lineIndex = lineIndex
         self.displayUTF16Range = displayUTF16Range
         self.sourceUTF16Range = sourceUTF16Range
+        self.displayRect = displayRect
         self.isTruncatedLine = isTruncatedLine
+        self.isExact = isExact
+    }
+}
+
+public struct PreparedTextDisplayedRect: Hashable, Sendable {
+    public var lineIndex: Int
+    public var rect: CGRect
+    public var displayUTF16Range: NSRange
+    public var sourceUTF16Range: NSRange?
+    public var isTruncatedLine: Bool
+    public var isExact: Bool
+
+    public init(
+        lineIndex: Int,
+        rect: CGRect,
+        displayUTF16Range: NSRange,
+        sourceUTF16Range: NSRange?,
+        isTruncatedLine: Bool,
+        isExact: Bool
+    ) {
+        self.lineIndex = lineIndex
+        self.rect = rect
+        self.displayUTF16Range = displayUTF16Range
+        self.sourceUTF16Range = sourceUTF16Range
+        self.isTruncatedLine = isTruncatedLine
+        self.isExact = isExact
     }
 }
 
 public struct PreparedTextSourceCoordinateSpan: Hashable, Sendable {
     public var displayUTF16Range: NSRange
     public var sourceUTF16Range: NSRange?
+    public var displayRect: CGRect?
 
-    public init(displayUTF16Range: NSRange, sourceUTF16Range: NSRange?) {
+    public init(
+        displayUTF16Range: NSRange,
+        sourceUTF16Range: NSRange?,
+        displayRect: CGRect? = nil
+    ) {
         self.displayUTF16Range = displayUTF16Range
         self.sourceUTF16Range = sourceUTF16Range
+        self.displayRect = displayRect
     }
 }
 
@@ -121,6 +158,7 @@ public struct PreparedTextSourceCoordinateLine: Hashable, Sendable {
     public var consumedSourceUTF16Range: NSRange
     public var sourceSpans: [PreparedTextSourceCoordinateSpan]
     public var isTruncated: Bool
+    public var displayFrame: CGRect
 
     public init(
         lineIndex: Int,
@@ -128,7 +166,8 @@ public struct PreparedTextSourceCoordinateLine: Hashable, Sendable {
         displayUTF16Length: Int,
         consumedSourceUTF16Range: NSRange,
         sourceSpans: [PreparedTextSourceCoordinateSpan],
-        isTruncated: Bool
+        isTruncated: Bool,
+        displayFrame: CGRect = .zero
     ) {
         self.lineIndex = lineIndex
         self.fragment = fragment
@@ -136,6 +175,7 @@ public struct PreparedTextSourceCoordinateLine: Hashable, Sendable {
         self.consumedSourceUTF16Range = consumedSourceUTF16Range
         self.sourceSpans = sourceSpans
         self.isTruncated = isTruncated
+        self.displayFrame = displayFrame
     }
 
     public var visibleSourceUTF16Ranges: [NSRange] {
@@ -171,6 +211,14 @@ public struct PreparedTextSourceCoordinateMap: Hashable, Sendable {
         lines.first { $0.lineIndex == index }
     }
 
+    public func displayedLineFrame(at index: Int) -> CGRect? {
+        line(at: index)?.displayFrame
+    }
+
+    public func sourceUTF16Ranges(onDisplayedLine lineIndex: Int) -> [NSRange] {
+        line(at: lineIndex)?.visibleSourceUTF16Ranges ?? []
+    }
+
     public func displayedSpans(forSourceUTF16Range sourceUTF16Range: NSRange) -> [PreparedTextDisplayedSpan] {
         guard sourceUTF16Range.length > 0 else {
             return []
@@ -188,7 +236,10 @@ public struct PreparedTextSourceCoordinateMap: Hashable, Sendable {
                 }
 
                 let displayRange: NSRange
-                if mappingMode == .exact, sourceRange.length == span.displayUTF16Range.length {
+                let canResolveExactDisplayRange = mappingMode == .exact &&
+                    sourceRange.length == span.displayUTF16Range.length
+                let isExact = canResolveExactDisplayRange && NSEqualRanges(intersection, sourceRange)
+                if canResolveExactDisplayRange {
                     let delta = intersection.location - sourceRange.location
                     displayRange = NSRange(
                         location: span.displayUTF16Range.location + delta,
@@ -203,13 +254,45 @@ public struct PreparedTextSourceCoordinateMap: Hashable, Sendable {
                         lineIndex: line.lineIndex,
                         displayUTF16Range: displayRange,
                         sourceUTF16Range: intersection,
-                        isTruncatedLine: line.isTruncated
+                        displayRect: span.displayRect,
+                        isTruncatedLine: line.isTruncated,
+                        isExact: isExact
                     )
                 )
             }
         }
 
         return matches
+    }
+
+    public func displayedRects(forSourceUTF16Range sourceUTF16Range: NSRange) -> [PreparedTextDisplayedRect] {
+        displayedRects(forSourceUTF16Range: sourceUTF16Range, onLine: nil)
+    }
+
+    public func displayedRects(
+        forSourceUTF16Range sourceUTF16Range: NSRange,
+        onLine lineIndex: Int?
+    ) -> [PreparedTextDisplayedRect] {
+        guard sourceUTF16Range.length > 0 else {
+            return []
+        }
+
+        return displayedSpans(forSourceUTF16Range: sourceUTF16Range).compactMap { span in
+            if let lineIndex, span.lineIndex != lineIndex {
+                return nil
+            }
+            guard let rect = span.displayRect, rect.isNull == false, rect.isEmpty == false else {
+                return nil
+            }
+            return PreparedTextDisplayedRect(
+                lineIndex: span.lineIndex,
+                rect: rect,
+                displayUTF16Range: span.displayUTF16Range,
+                sourceUTF16Range: span.sourceUTF16Range,
+                isTruncatedLine: span.isTruncatedLine,
+                isExact: span.isExact
+            )
+        }
     }
 
     public func sourceUTF16Ranges(
@@ -268,6 +351,18 @@ public struct PreparedTextSourceCoordinateMap: Hashable, Sendable {
 
     public func visibleAttachmentSpans(in prepared: PreparedText) -> [PreparedAttachmentSpan] {
         prepared.attachmentSpans.filter { isSourceRangeVisible($0.sourceUTF16Range) }
+    }
+
+    public func displayedRects(for token: PreparedToken) -> [PreparedTextDisplayedRect] {
+        displayedRects(forSourceUTF16Range: token.sourceUTF16Range)
+    }
+
+    public func displayedRects(for annotation: PreparedAnnotation) -> [PreparedTextDisplayedRect] {
+        displayedRects(forSourceUTF16Range: annotation.sourceUTF16Range)
+    }
+
+    public func displayedRects(for attachmentSpan: PreparedAttachmentSpan) -> [PreparedTextDisplayedRect] {
+        displayedRects(forSourceUTF16Range: attachmentSpan.sourceUTF16Range)
     }
 }
 
@@ -335,16 +430,33 @@ public struct PreparedTextDisplayPacket {
     }
 
     public var sourceCoordinateMap: PreparedTextSourceCoordinateMap {
-        PreparedTextSourceCoordinateMap(
+        var originY: CGFloat = 0
+        return PreparedTextSourceCoordinateMap(
             mappingMode: sourceCoordinateMappingMode,
             lines: lines.enumerated().map { index, line in
-                PreparedTextSourceCoordinateLine(
+                defer { originY += line.fragment.blockAdvance }
+                let lineFrame = preparedCoordinateDisplayFrame(
+                    originX: line.originX,
+                    originY: originY,
+                    lineWidth: line.lineWidth,
+                    fragment: line.fragment
+                )
+                return PreparedTextSourceCoordinateLine(
                     lineIndex: index,
                     fragment: line.fragment,
                     displayUTF16Length: line.attributedText.length,
                     consumedSourceUTF16Range: line.consumedSourceUTF16Range,
-                    sourceSpans: line.sourceSpans,
-                    isTruncated: line.isTruncated
+                    sourceSpans: preparedCoordinateSpans(
+                        from: line.sourceSpans,
+                        attributedText: line.attributedText,
+                        ctLine: line.ctLine,
+                        originX: line.originX,
+                        originY: originY,
+                        lineWidth: line.lineWidth,
+                        fragment: line.fragment
+                    ),
+                    isTruncated: line.isTruncated,
+                    displayFrame: lineFrame
                 )
             }
         )
@@ -397,6 +509,10 @@ public extension PreparedToken {
         map.displayedSpans(forSourceUTF16Range: sourceUTF16Range)
     }
 
+    func displayedRects(in map: PreparedTextSourceCoordinateMap) -> [PreparedTextDisplayedRect] {
+        map.displayedRects(for: self)
+    }
+
     func isVisible(in map: PreparedTextSourceCoordinateMap) -> Bool {
         map.isSourceRangeVisible(sourceUTF16Range)
     }
@@ -407,6 +523,10 @@ public extension PreparedAnnotation {
         map.displayedSpans(forSourceUTF16Range: sourceUTF16Range)
     }
 
+    func displayedRects(in map: PreparedTextSourceCoordinateMap) -> [PreparedTextDisplayedRect] {
+        map.displayedRects(for: self)
+    }
+
     func isVisible(in map: PreparedTextSourceCoordinateMap) -> Bool {
         map.isSourceRangeVisible(sourceUTF16Range)
     }
@@ -415,6 +535,10 @@ public extension PreparedAnnotation {
 public extension PreparedAttachmentSpan {
     func displayedSpans(in map: PreparedTextSourceCoordinateMap) -> [PreparedTextDisplayedSpan] {
         map.displayedSpans(forSourceUTF16Range: sourceUTF16Range)
+    }
+
+    func displayedRects(in map: PreparedTextSourceCoordinateMap) -> [PreparedTextDisplayedRect] {
+        map.displayedRects(for: self)
     }
 
     func isVisible(in map: PreparedTextSourceCoordinateMap) -> Bool {
@@ -1095,15 +1219,156 @@ private struct PreparedTextDisplayLayoutBuilder {
         lineWidth: CGFloat,
         containerWidth: CGFloat
     ) -> CGFloat {
-        switch alignment {
-        case .center:
-            return max((containerWidth - lineWidth) / 2, 0)
-        case .right:
-            return max(containerWidth - lineWidth, 0)
-        case .left, .leading, .trailing, .natural:
-            return 0
-        }
+        preparedCoordinateHorizontalOrigin(
+            alignment: alignment,
+            lineWidth: lineWidth,
+            containerWidth: containerWidth
+        )
     }
+}
+
+func preparedCoordinateHorizontalOrigin(
+    alignment: PreparedTextHorizontalAlignment,
+    lineWidth: CGFloat,
+    containerWidth: CGFloat
+) -> CGFloat {
+    switch alignment {
+    case .center:
+        return max((containerWidth - lineWidth) / 2, 0)
+    case .right:
+        return max(containerWidth - lineWidth, 0)
+    case .left, .leading, .trailing, .natural:
+        return 0
+    }
+}
+
+func preparedCoordinateDisplayFrame(
+    originX: CGFloat,
+    originY: CGFloat,
+    lineWidth: CGFloat,
+    fragment: LineFragment
+) -> CGRect {
+    let typographicTop = originY + fragment.paragraphSpacingBefore
+    let typographicHeight = max(fragment.ascent + fragment.descent + fragment.leading, 1)
+    return CGRect(x: originX, y: typographicTop, width: lineWidth, height: typographicHeight)
+}
+
+func preparedCoordinateSpans(
+    from spans: [PreparedTextSourceCoordinateSpan],
+    attributedText: NSAttributedString,
+    ctLine: CTLine,
+    originX: CGFloat,
+    originY: CGFloat,
+    lineWidth: CGFloat,
+    fragment: LineFragment
+) -> [PreparedTextSourceCoordinateSpan] {
+    spans.flatMap { span -> [PreparedTextSourceCoordinateSpan] in
+        guard
+            let sourceRange = span.sourceUTF16Range,
+            sourceRange.length == span.displayUTF16Range.length,
+            sourceRange.length > 1
+        else {
+            return [
+                PreparedTextSourceCoordinateSpan(
+                    displayUTF16Range: span.displayUTF16Range,
+                    sourceUTF16Range: span.sourceUTF16Range,
+                    displayRect: preparedCoordinateRect(
+                        for: span.displayUTF16Range,
+                        ctLine: ctLine,
+                        originX: originX,
+                        originY: originY,
+                        lineWidth: lineWidth,
+                        fragment: fragment
+                    )
+                ),
+            ]
+        }
+
+        let displayNSString = attributedText.string as NSString
+        let spanEnd = NSMaxRange(span.displayUTF16Range)
+        var slices: [PreparedTextSourceCoordinateSpan] = []
+        var cursor = span.displayUTF16Range.location
+
+        while cursor < spanEnd {
+            let displaySlice = displayNSString.rangeOfComposedCharacterSequence(at: cursor)
+            let clampedLength = min(NSMaxRange(displaySlice), spanEnd) - cursor
+            let resolvedDisplaySlice = NSRange(location: cursor, length: max(clampedLength, 0))
+            guard resolvedDisplaySlice.length > 0 else {
+                cursor += 1
+                continue
+            }
+
+            let delta = resolvedDisplaySlice.location - span.displayUTF16Range.location
+            let sourceSlice = NSRange(location: sourceRange.location + delta, length: resolvedDisplaySlice.length)
+            slices.append(
+                PreparedTextSourceCoordinateSpan(
+                    displayUTF16Range: resolvedDisplaySlice,
+                    sourceUTF16Range: sourceSlice,
+                    displayRect: preparedCoordinateRect(
+                        for: resolvedDisplaySlice,
+                        ctLine: ctLine,
+                        originX: originX,
+                        originY: originY,
+                        lineWidth: lineWidth,
+                        fragment: fragment
+                    )
+                )
+            )
+            cursor = NSMaxRange(resolvedDisplaySlice)
+        }
+
+        return slices.isEmpty ? [
+            PreparedTextSourceCoordinateSpan(
+                displayUTF16Range: span.displayUTF16Range,
+                sourceUTF16Range: span.sourceUTF16Range,
+                displayRect: preparedCoordinateRect(
+                    for: span.displayUTF16Range,
+                    ctLine: ctLine,
+                    originX: originX,
+                    originY: originY,
+                    lineWidth: lineWidth,
+                    fragment: fragment
+                )
+            ),
+        ] : slices
+    }
+}
+
+func preparedCoordinateRect(
+    for displayUTF16Range: NSRange,
+    ctLine: CTLine,
+    originX: CGFloat,
+    originY: CGFloat,
+    lineWidth: CGFloat,
+    fragment: LineFragment
+) -> CGRect? {
+    guard displayUTF16Range.length > 0 else {
+        return nil
+    }
+
+    let lineLength = CTLineGetStringRange(ctLine).length
+    let displayEnd = min(NSMaxRange(displayUTF16Range), lineLength)
+    let displayStart = min(max(displayUTF16Range.location, 0), displayEnd)
+    guard displayEnd > displayStart else {
+        return nil
+    }
+
+    let localStart = CGFloat(CTLineGetOffsetForStringIndex(ctLine, displayStart, nil))
+    let localEnd: CGFloat
+    if displayEnd >= lineLength {
+        localEnd = lineWidth
+    } else {
+        localEnd = CGFloat(CTLineGetOffsetForStringIndex(ctLine, displayEnd, nil))
+    }
+
+    let minLocalX = min(localStart, localEnd)
+    let rect = preparedCoordinateDisplayFrame(
+        originX: originX,
+        originY: originY,
+        lineWidth: max(localEnd - localStart, 0),
+        fragment: fragment
+    ).offsetBy(dx: minLocalX, dy: 0)
+    return rect.isNull || rect.isEmpty ? nil : rect
 }
 
 private struct ComposedCharacterTable {

--- a/Sources/PretextCore/Engine/PreparedTextDisplayLayout.swift
+++ b/Sources/PretextCore/Engine/PreparedTextDisplayLayout.swift
@@ -1365,7 +1365,7 @@ func preparedCoordinateRect(
     let rect = preparedCoordinateDisplayFrame(
         originX: originX,
         originY: originY,
-        lineWidth: max(localEnd - localStart, 0),
+        lineWidth: abs(localEnd - localStart),
         fragment: fragment
     ).offsetBy(dx: minLocalX, dy: 0)
     return rect.isNull || rect.isEmpty ? nil : rect

--- a/Sources/PretextCore/Engine/PreparedTextEngine.swift
+++ b/Sources/PretextCore/Engine/PreparedTextEngine.swift
@@ -54,7 +54,7 @@ public extension PreparedTextEngine {
 
 public final class DefaultPreparedTextEngine: PreparedTextEngine {
     public let measurer: CachedFramesetterTextMeasurer
-    public let attachmentResolver: PreparedAttachmentResolving?
+    public let attachmentResolver: PreparedAttachmentResolver?
 
     private let segmentMeasurementCache = SegmentMeasurementCache()
     private let preparedTextCache = CostBoundCache<PreparedTextCacheKey, PreparedText>(
@@ -86,7 +86,7 @@ public final class DefaultPreparedTextEngine: PreparedTextEngine {
 
     public init(
         measurer: CachedFramesetterTextMeasurer = CachedFramesetterTextMeasurer(),
-        attachmentResolver: PreparedAttachmentResolving? = PreparedAttachmentRegistry.shared
+        attachmentResolver: PreparedAttachmentResolver? = PreparedAttachmentRegistry.shared
     ) {
         self.measurer = measurer
         self.attachmentResolver = attachmentResolver

--- a/Sources/PretextCore/Engine/PreparedTextTypes.swift
+++ b/Sources/PretextCore/Engine/PreparedTextTypes.swift
@@ -179,16 +179,40 @@ public struct PreparedLayoutPacket {
     }
 
     public var sourceCoordinateMap: PreparedTextSourceCoordinateMap {
-        PreparedTextSourceCoordinateMap(
+        let containerWidth = max(result.maxPaintWidth, 0)
+        var originY: CGFloat = 0
+        return PreparedTextSourceCoordinateMap(
             mappingMode: sourceCoordinateMappingMode,
             lines: lines.enumerated().map { index, line in
-                PreparedTextSourceCoordinateLine(
+                defer { originY += line.fragment.blockAdvance }
+                let lineWidth = line.fragment.paintWidth
+                let originX = preparedCoordinateHorizontalOrigin(
+                    alignment: line.resolvedAlignment,
+                    lineWidth: lineWidth,
+                    containerWidth: containerWidth
+                )
+                let displayFrame = preparedCoordinateDisplayFrame(
+                    originX: originX,
+                    originY: originY,
+                    lineWidth: lineWidth,
+                    fragment: line.fragment
+                )
+                return PreparedTextSourceCoordinateLine(
                     lineIndex: index,
                     fragment: line.fragment,
                     displayUTF16Length: line.attributedText.length,
                     consumedSourceUTF16Range: line.consumedSourceUTF16Range,
-                    sourceSpans: line.sourceSpans,
-                    isTruncated: line.isTruncated
+                    sourceSpans: preparedCoordinateSpans(
+                        from: line.sourceSpans,
+                        attributedText: line.attributedText,
+                        ctLine: line.ctLine,
+                        originX: originX,
+                        originY: originY,
+                        lineWidth: lineWidth,
+                        fragment: line.fragment
+                    ),
+                    isTruncated: line.isTruncated,
+                    displayFrame: displayFrame
                 )
             }
         )

--- a/Sources/PretextCore/System/PreparedTextAttachments.swift
+++ b/Sources/PretextCore/System/PreparedTextAttachments.swift
@@ -43,8 +43,43 @@ public struct PreparedResolvedAttachment: Hashable, Sendable {
     }
 }
 
+public enum PreparedAttachmentLifecycleState: Hashable, Sendable {
+    case placeholder(PreparedAttachmentReference)
+    case resolved(PreparedAttachmentReference, PreparedResolvedAttachment)
+
+    public var reference: PreparedAttachmentReference {
+        switch self {
+        case let .placeholder(reference), let .resolved(reference, _):
+            return reference
+        }
+    }
+
+    public var resolvedAttachment: PreparedResolvedAttachment? {
+        switch self {
+        case .placeholder:
+            return nil
+        case let .resolved(_, resolvedAttachment):
+            return resolvedAttachment
+        }
+    }
+
+    public var resolvedBounds: CGRect {
+        resolvedAttachment?.bounds ?? reference.placeholderBounds
+    }
+}
+
 public protocol PreparedAttachmentResolving: AnyObject, Sendable {
     func resolvedAttachment(for reference: PreparedAttachmentReference) -> PreparedResolvedAttachment?
+}
+
+public protocol PreparedAttachmentResolver: PreparedAttachmentResolving {
+    func attachmentState(for reference: PreparedAttachmentReference) -> PreparedAttachmentLifecycleState
+}
+
+public extension PreparedAttachmentResolver {
+    func resolvedAttachment(for reference: PreparedAttachmentReference) -> PreparedResolvedAttachment? {
+        attachmentState(for: reference).resolvedAttachment
+    }
 }
 
 public extension NSAttributedString.Key {
@@ -84,7 +119,7 @@ public final class PreparedTextAttachment: NSTextAttachment {
     }
 }
 
-public final class PreparedAttachmentRegistry: @unchecked Sendable, PreparedAttachmentResolving {
+public final class PreparedAttachmentRegistry: @unchecked Sendable, PreparedAttachmentResolver {
     public static let shared = PreparedAttachmentRegistry()
 
     private let lock = NSLock()
@@ -100,6 +135,25 @@ public final class PreparedAttachmentRegistry: @unchecked Sendable, PreparedAtta
     public func resolvedAttachment(for reference: PreparedAttachmentReference) -> PreparedResolvedAttachment? {
         lock.withLock {
             resolvedAttachments[reference.id]
+        }
+    }
+
+    public func attachmentState(for reference: PreparedAttachmentReference) -> PreparedAttachmentLifecycleState {
+        if let resolvedAttachment = resolvedAttachment(for: reference) {
+            return .resolved(reference, resolvedAttachment)
+        }
+        return .placeholder(reference)
+    }
+
+    public func setAttachmentState(
+        _ state: PreparedAttachmentLifecycleState,
+        invalidate sourceIDs: Set<PreparedTextSourceID>? = nil
+    ) {
+        switch state {
+        case let .placeholder(reference):
+            setResolvedAttachment(nil, for: reference.id, invalidate: sourceIDs)
+        case let .resolved(reference, resolvedAttachment):
+            setResolvedAttachment(resolvedAttachment, for: reference.id, invalidate: sourceIDs)
         }
     }
 
@@ -127,6 +181,36 @@ public final class PreparedAttachmentRegistry: @unchecked Sendable, PreparedAtta
         } else {
             invalidationCenter.invalidate(sourceIDs: targetSourceIDs, reason: .attachmentMetricsChanged)
         }
+    }
+
+    public func removeResolvedAttachment(
+        for id: PreparedAttachmentID,
+        invalidate sourceIDs: Set<PreparedTextSourceID>? = nil
+    ) {
+        setResolvedAttachment(nil, for: id, invalidate: sourceIDs)
+    }
+
+    public func recordedSourceIDs(for id: PreparedAttachmentID) -> Set<PreparedTextSourceID> {
+        lock.withLock {
+            recordedSourceUsage[id] ?? []
+        }
+    }
+
+    public func invalidateRecordedSources(
+        for attachmentIDs: Set<PreparedAttachmentID>,
+        reason: PreparedInvalidationReason = .attachmentMetricsChanged
+    ) {
+        let sourceIDs = lock.withLock {
+            attachmentIDs.reduce(into: Set<PreparedTextSourceID>()) { partialResult, attachmentID in
+                partialResult.formUnion(recordedSourceUsage[attachmentID] ?? [])
+            }
+        }
+
+        guard sourceIDs.isEmpty == false else {
+            return
+        }
+
+        invalidationCenter.invalidate(sourceIDs: sourceIDs, reason: reason)
     }
 
     func recordUsage(of attachmentIDs: Set<PreparedAttachmentID>, sourceID: PreparedTextSourceID?) {

--- a/Sources/PretextCore/System/PreparedTextSystem.swift
+++ b/Sources/PretextCore/System/PreparedTextSystem.swift
@@ -20,7 +20,7 @@ public final class PreparedTextSystem: NSObject {
 
     public let measurer: CachedFramesetterTextMeasurer
     public let engine: DefaultPreparedTextEngine
-    public let attachmentResolver: PreparedAttachmentResolving?
+    public let attachmentResolver: PreparedAttachmentResolver?
 
     private let invalidationCenter: PreparedInvalidationCenter
     private var observerTokens: [ObserverToken] = []
@@ -28,7 +28,7 @@ public final class PreparedTextSystem: NSObject {
     public init(
         measurer: CachedFramesetterTextMeasurer = CachedFramesetterTextMeasurer(),
         invalidationCenter: PreparedInvalidationCenter = .shared,
-        attachmentResolver: PreparedAttachmentResolving? = PreparedAttachmentRegistry.shared
+        attachmentResolver: PreparedAttachmentResolver? = PreparedAttachmentRegistry.shared
     ) {
         self.measurer = measurer
         self.attachmentResolver = attachmentResolver

--- a/Sources/PretextUIKit/Demo/PreparedTextUIKitExamples.swift
+++ b/Sources/PretextUIKit/Demo/PreparedTextUIKitExamples.swift
@@ -199,7 +199,7 @@ public struct PreparedTextUIKitDemoItem: Hashable {
         )
 
         let attachmentTokenCard = NSMutableAttributedString(
-            string: " \nMedia @ops #prepared-layout keeps a checklist link visible even when the card self-sizes around inline attachment metrics.",
+            string: " \nMedia @ops #prepared-layout keeps checklist link and policy link individually visible even when the card self-sizes around inline attachment metrics.",
             attributes: [.font: bodyFont]
         )
         let demoAttachment = PreparedTextAttachment(
@@ -212,12 +212,27 @@ public struct PreparedTextUIKitDemoItem: Hashable {
         if let image = UIImage(systemName: "paperclip.circle.fill") {
             demoAttachment.image = image
         }
+        PreparedAttachmentRegistry.shared.setAttachmentState(
+            .resolved(
+                demoAttachment.reference,
+                PreparedResolvedAttachment(
+                    bounds: CGRect(x: 0, y: -2, width: 24, height: 18),
+                    contentIdentity: "uikit-demo-paperclip"
+                )
+            ),
+            invalidate: []
+        )
         attachmentTokenCard.addAttribute(.attachment, value: demoAttachment, range: NSRange(location: 0, length: 1))
         attachmentTokenCard.addAttribute(.preparedAttachmentReference, value: demoAttachment.reference, range: NSRange(location: 0, length: 1))
         let checklistRange = (attachmentTokenCard.string as NSString).range(of: "checklist link")
         if checklistRange.location != NSNotFound, checklistRange.length > 0 {
             attachmentTokenCard.addAttribute(.link, value: URL(string: "https://example.com/checklist")!, range: checklistRange)
             attachmentTokenCard.addAttribute(.underlineStyle, value: NSUnderlineStyle.single.rawValue, range: checklistRange)
+        }
+        let policyRange = (attachmentTokenCard.string as NSString).range(of: "policy link")
+        if policyRange.location != NSNotFound, policyRange.length > 0 {
+            attachmentTokenCard.addAttribute(.link, value: URL(string: "https://example.com/policy")!, range: policyRange)
+            attachmentTokenCard.addAttribute(.underlineStyle, value: NSUnderlineStyle.single.rawValue, range: policyRange)
         }
 
         let baseItems = [
@@ -319,8 +334,8 @@ public struct PreparedTextUIKitDemoItem: Hashable {
             ),
             PreparedTextUIKitDemoItem(
                 title: "Prepared Structure",
-                subtitle: "Inline attachment, mention, hashtag, and link",
-                note: "Phase 3 keeps attachment metrics, token inspection, and visible-range mapping in the same prepared surface.",
+                subtitle: "Inline attachment, mention, hashtag, and multi-link accessibility",
+                note: "Round 1 keeps attachment resolver state, per-link accessibility, and visible-range geometry in the same prepared surface.",
                 body: attachmentTokenCard,
                 surfaceMode: .stage1Prepared,
                 numberOfLines: 3,
@@ -330,7 +345,7 @@ public struct PreparedTextUIKitDemoItem: Hashable {
                     UIColor(red: 0.95, green: 0.93, blue: 0.99, alpha: 1.0),
                     UIColor(red: 0.19, green: 0.15, blue: 0.27, alpha: 1.0)
                 ),
-                capabilityTags: ["Attachment", "@mention", "#hashtag", "Coordinate map"],
+                capabilityTags: ["Attachment", "@mention", "#hashtag", "AX links"],
                 sourceID: PreparedTextSourceID("uikit-prepared-structure")
             ),
         ]

--- a/Sources/PretextUIKit/Stage1/PreparedLabelView.swift
+++ b/Sources/PretextUIKit/Stage1/PreparedLabelView.swift
@@ -350,6 +350,7 @@ public final class PreparedLabelView: UIView {
         isOpaque = false
         contentMode = .redraw
         isAccessibilityElement = true
+        shouldGroupAccessibilityChildren = true
         isUserInteractionEnabled = true
         accessibilityTraits.insert(.staticText)
         tapGestureRecognizer.cancelsTouchesInView = false
@@ -477,21 +478,38 @@ public final class PreparedLabelView: UIView {
         return resolved
     }
 
-    private func visibleLinks() -> [AttributedLink] {
-        let layoutWidth = resolvedDrawWidth()
-        let containerWidth = bounds.width > 0 ? bounds.width : layoutWidth
-        guard let packet = resolvedDisplayPacket(layoutWidth: layoutWidth, containerWidth: containerWidth) else {
-            return resolvedInputText()?.links() ?? []
+    private func visibleLinks() -> [PreparedVisibleLink] {
+        guard let inputText = resolvedInputText() else {
+            return []
         }
 
-        var links: [AttributedLink] = []
-        var seenURLs = Set<URL>()
-        for line in packet.lines {
-            for link in line.attributedText.links() where seenURLs.insert(link.url).inserted {
-                links.append(link)
-            }
+        let layoutWidth = resolvedDrawWidth()
+        let containerWidth = bounds.width > 0 ? bounds.width : layoutWidth
+        guard
+            let prepared = resolvedPreparedText(),
+            let packet = resolvedDisplayPacket(layoutWidth: layoutWidth, containerWidth: containerWidth)
+        else {
+            return inputText.links().map(PreparedVisibleLink.init(link:))
         }
-        return links
+
+        let map = packet.sourceCoordinateMap
+        return map.visibleAnnotations(in: prepared)
+            .filter { $0.kind == .link }
+            .compactMap { annotation in
+                guard
+                    let destination = annotation.linkDestination,
+                    let url = URL(string: destination)
+                else {
+                    return nil
+                }
+
+                return PreparedVisibleLink(
+                    range: annotation.sourceUTF16Range,
+                    url: url,
+                    title: annotation.sourceText,
+                    displayedRects: map.displayedRects(for: annotation)
+                )
+            }
     }
 
     private func activate(url: URL) -> Bool {
@@ -525,6 +543,8 @@ public final class PreparedLabelView: UIView {
     }
 
     private func updateAccessibilityMetadata() {
+        accessibilityElements = nil
+        isAccessibilityElement = true
         accessibilityLabel = resolvedInputText()?.string
         accessibilityValue = nil
         accessibilityHint = nil
@@ -544,6 +564,14 @@ public final class PreparedLabelView: UIView {
             return
         }
 
+        if links.count > 1,
+           let accessibilityElements = accessibilityElements(for: attributedText, links: links) {
+            isAccessibilityElement = false
+            accessibilityTraits.remove(.link)
+            self.accessibilityElements = accessibilityElements
+            return
+        }
+
         if links.count == 1, links[0].range == NSRange(location: 0, length: attributedText.length) {
             accessibilityTraits.insert(.link)
         } else {
@@ -556,6 +584,36 @@ public final class PreparedLabelView: UIView {
                 self?.activate(url: link.url) ?? false
             }
         }
+    }
+
+    private func accessibilityElements(
+        for attributedText: NSAttributedString,
+        links: [PreparedVisibleLink]
+    ) -> [Any]? {
+        let linkElements = links.compactMap { link -> PreparedLabelLinkAccessibilityElement? in
+            guard let frame = link.accessibilityFrameInContainerSpace else {
+                return nil
+            }
+
+            let element = PreparedLabelLinkAccessibilityElement(container: self) { [weak self] in
+                self?.activate(url: link.url) ?? false
+            }
+            element.accessibilityLabel = link.title.isEmpty ? link.url.absoluteString : link.title
+            element.accessibilityTraits = [.link]
+            element.accessibilityFrameInContainerSpace = frame
+            return element
+        }
+
+        guard linkElements.count == links.count else {
+            return nil
+        }
+
+        let summaryElement = UIAccessibilityElement(accessibilityContainer: self)
+        summaryElement.accessibilityLabel = attributedText.string
+        summaryElement.accessibilityAttributedLabel = attributedText
+        summaryElement.accessibilityTraits = [.staticText]
+        summaryElement.accessibilityFrameInContainerSpace = bounds
+        return [summaryElement] + linkElements
     }
 
     private func updateConfiguration(_ mutate: (inout PreparedLabelConfiguration) -> Void) {
@@ -663,6 +721,57 @@ private struct AttributedLink {
     var range: NSRange
     var url: URL
     var title: String
+}
+
+private struct PreparedVisibleLink: Hashable {
+    var range: NSRange
+    var url: URL
+    var title: String
+    var displayedRects: [PreparedTextDisplayedRect]
+
+    init(
+        range: NSRange,
+        url: URL,
+        title: String,
+        displayedRects: [PreparedTextDisplayedRect]
+    ) {
+        self.range = range
+        self.url = url
+        self.title = title
+        self.displayedRects = displayedRects
+    }
+
+    init(link: AttributedLink) {
+        self.init(
+            range: link.range,
+            url: link.url,
+            title: link.title,
+            displayedRects: []
+        )
+    }
+
+    var accessibilityFrameInContainerSpace: CGRect? {
+        let unionRect = displayedRects.reduce(into: CGRect.null) { partialResult, displayedRect in
+            partialResult = partialResult.union(displayedRect.rect)
+        }
+        guard unionRect.isNull == false, unionRect.isEmpty == false else {
+            return nil
+        }
+        return unionRect.insetBy(dx: -2, dy: -2)
+    }
+}
+
+private final class PreparedLabelLinkAccessibilityElement: UIAccessibilityElement {
+    private let activationHandler: () -> Bool
+
+    init(container: Any, activationHandler: @escaping () -> Bool) {
+        self.activationHandler = activationHandler
+        super.init(accessibilityContainer: container)
+    }
+
+    override func accessibilityActivate() -> Bool {
+        activationHandler()
+    }
 }
 
 public struct PreparedTextUIKitExampleItem: Hashable {

--- a/Sources/PretextUIKit/Stage1/PreparedTextObstacleLayout.swift
+++ b/Sources/PretextUIKit/Stage1/PreparedTextObstacleLayout.swift
@@ -578,7 +578,7 @@ private func preparedObstacleCoordinateRect(
     let rect = preparedObstacleCoordinateDisplayFrame(
         originX: originX + min(localStart, localEnd),
         originY: originY,
-        lineWidth: max(localEnd - localStart, 0),
+        lineWidth: abs(localEnd - localStart),
         fragment: fragment
     )
     return rect.isNull || rect.isEmpty ? nil : rect

--- a/Sources/PretextUIKit/Stage1/PreparedTextObstacleLayout.swift
+++ b/Sources/PretextUIKit/Stage1/PreparedTextObstacleLayout.swift
@@ -13,8 +13,19 @@ public struct PreparedTextObstacleCircle: Hashable {
     }
 }
 
+public struct PreparedTextObstacleRoundedRect: Hashable {
+    public var rect: CGRect
+    public var cornerRadius: CGFloat
+
+    public init(rect: CGRect, cornerRadius: CGFloat) {
+        self.rect = rect
+        self.cornerRadius = max(cornerRadius, 0)
+    }
+}
+
 public enum PreparedObstacleShape: Hashable {
     case circle(PreparedTextObstacleCircle)
+    case roundedRect(PreparedTextObstacleRoundedRect)
 }
 
 public struct PreparedObstacle: Hashable {
@@ -28,10 +39,25 @@ public struct PreparedObstacle: Hashable {
         self.shape = .circle(circle)
     }
 
+    public init(roundedRect: PreparedTextObstacleRoundedRect) {
+        self.shape = .roundedRect(roundedRect)
+    }
+
     public var circle: PreparedTextObstacleCircle? {
         switch shape {
         case let .circle(circle):
             return circle
+        case .roundedRect:
+            return nil
+        }
+    }
+
+    public var roundedRect: PreparedTextObstacleRoundedRect? {
+        switch shape {
+        case .circle:
+            return nil
+        case let .roundedRect(roundedRect):
+            return roundedRect
         }
     }
 }
@@ -145,29 +171,39 @@ public struct PreparedTextObstacleLayoutResult {
             lines: fragments.enumerated().map { index, fragment in
                 let start = prepared.cursor(forUTF16Offset: fragment.sourceUTF16Range.location)
                 let end = prepared.cursor(forUTF16Offset: NSMaxRange(fragment.sourceUTF16Range))
+                let lineFragment = preparedObstacleLineFragment(
+                    start: start,
+                    end: end,
+                    spanWidth: fragment.spanWidth,
+                    ascent: fragment.ascent,
+                    descent: fragment.descent,
+                    leading: fragment.leading,
+                    rowHeight: rowHeight
+                )
+                let displayFrame = preparedObstacleCoordinateDisplayFrame(
+                    originX: fragment.originX,
+                    originY: fragment.rowY,
+                    lineWidth: fragment.spanWidth,
+                    fragment: lineFragment
+                )
+                let sourceSpans = preparedObstacleCoordinateSpans(
+                    attributedText: fragment.attributedText,
+                    sourceUTF16Range: fragment.sourceUTF16Range,
+                    mappingMode: prepared.sourceCoordinateMappingMode,
+                    ctLine: fragment.ctLine,
+                    originX: fragment.originX,
+                    originY: fragment.rowY,
+                    lineWidth: fragment.spanWidth,
+                    fragment: lineFragment
+                )
                 return PreparedTextSourceCoordinateLine(
                     lineIndex: index,
-                    fragment: LineFragment(
-                        start: start,
-                        end: end,
-                        paintEnd: end,
-                        fitWidth: fragment.spanWidth,
-                        paintWidth: fragment.spanWidth,
-                        trailingWhitespaceWidth: 0,
-                        ascent: fragment.ascent,
-                        descent: fragment.descent,
-                        leading: fragment.leading,
-                        blockAdvance: rowHeight
-                    ),
+                    fragment: lineFragment,
                     displayUTF16Length: fragment.attributedText.length,
                     consumedSourceUTF16Range: fragment.sourceUTF16Range,
-                    sourceSpans: [
-                        PreparedTextSourceCoordinateSpan(
-                            displayUTF16Range: NSRange(location: 0, length: fragment.attributedText.length),
-                            sourceUTF16Range: fragment.sourceUTF16Range
-                        ),
-                    ],
-                    isTruncated: false
+                    sourceSpans: sourceSpans,
+                    isTruncated: false,
+                    displayFrame: displayFrame
                 )
             }
         )
@@ -245,7 +281,7 @@ public final class PreparedTextObstacleLayouter {
             let spans = availableSpans(
                 in: bandRect,
                 textRect: textRect,
-                obstacles: circles,
+                obstacles: obstacles,
                 obstaclePadding: obstaclePadding,
                 minimumSpanWidth: minimumSpanWidth
             )
@@ -344,7 +380,7 @@ public final class PreparedTextObstacleLayouter {
     private func availableSpans(
         in bandRect: CGRect,
         textRect: CGRect,
-        obstacles: [PreparedTextObstacleCircle],
+        obstacles: [PreparedObstacle],
         obstaclePadding: CGFloat,
         minimumSpanWidth: CGFloat
     ) -> [PreparedTextObstacleHorizontalSpan] {
@@ -382,26 +418,64 @@ public final class PreparedTextObstacleLayouter {
     private func mergedExclusionIntervals(
         in bandRect: CGRect,
         textRect: CGRect,
-        obstacles: [PreparedTextObstacleCircle],
+        obstacles: [PreparedObstacle],
         obstaclePadding: CGFloat
     ) -> [PreparedTextObstacleHorizontalSpan] {
         let midY = bandRect.midY
         var intervals: [PreparedTextObstacleHorizontalSpan] = []
 
         for obstacle in obstacles {
-            let layoutRadius = obstacle.radius + obstaclePadding
-            let distanceY = abs(midY - obstacle.center.y)
-            guard distanceY < layoutRadius else {
-                continue
-            }
+            switch obstacle.shape {
+            case let .circle(circle):
+                let layoutRadius = circle.radius + obstaclePadding
+                let distanceY = abs(midY - circle.center.y)
+                guard distanceY < layoutRadius else {
+                    continue
+                }
 
-            let deltaX = sqrt(max((layoutRadius * layoutRadius) - (distanceY * distanceY), 0))
-            let minX = max(textRect.minX, obstacle.center.x - deltaX)
-            let maxX = min(textRect.maxX, obstacle.center.x + deltaX)
-            guard maxX - minX > 0 else {
-                continue
+                let deltaX = sqrt(max((layoutRadius * layoutRadius) - (distanceY * distanceY), 0))
+                let minX = max(textRect.minX, circle.center.x - deltaX)
+                let maxX = min(textRect.maxX, circle.center.x + deltaX)
+                guard maxX - minX > 0 else {
+                    continue
+                }
+                intervals.append(PreparedTextObstacleHorizontalSpan(minX: minX, maxX: maxX))
+            case let .roundedRect(roundedRect):
+                let layoutRect = roundedRect.rect.insetBy(dx: -obstaclePadding, dy: -obstaclePadding)
+                guard layoutRect.minY < midY, midY < layoutRect.maxY else {
+                    continue
+                }
+
+                let cornerRadius = min(
+                    max(roundedRect.cornerRadius + obstaclePadding, 0),
+                    min(layoutRect.width, layoutRect.height) / 2
+                )
+                var minX = layoutRect.minX
+                var maxX = layoutRect.maxX
+
+                if cornerRadius > 0 {
+                    let topCornerCenterY = layoutRect.minY + cornerRadius
+                    let bottomCornerCenterY = layoutRect.maxY - cornerRadius
+                    if midY < topCornerCenterY {
+                        let distanceY = topCornerCenterY - midY
+                        let deltaX = sqrt(max((cornerRadius * cornerRadius) - (distanceY * distanceY), 0))
+                        minX = layoutRect.minX + cornerRadius - deltaX
+                        maxX = layoutRect.maxX - cornerRadius + deltaX
+                    } else if midY > bottomCornerCenterY {
+                        let distanceY = midY - bottomCornerCenterY
+                        let deltaX = sqrt(max((cornerRadius * cornerRadius) - (distanceY * distanceY), 0))
+                        minX = layoutRect.minX + cornerRadius - deltaX
+                        maxX = layoutRect.maxX - cornerRadius + deltaX
+                    }
+                }
+
+                minX = max(textRect.minX, minX)
+                maxX = min(textRect.maxX, maxX)
+                guard maxX - minX > 0 else {
+                    continue
+                }
+                intervals.append(PreparedTextObstacleHorizontalSpan(minX: minX, maxX: maxX))
             }
-            intervals.append(PreparedTextObstacleHorizontalSpan(minX: minX, maxX: maxX))
         }
 
         let sorted = intervals.sorted { lhs, rhs in
@@ -438,4 +512,135 @@ private struct PreparedTextObstacleHorizontalSpan: Hashable {
     var width: CGFloat {
         max(maxX - minX, 0)
     }
+}
+
+private func preparedObstacleLineFragment(
+    start: LayoutCursor,
+    end: LayoutCursor,
+    spanWidth: CGFloat,
+    ascent: CGFloat,
+    descent: CGFloat,
+    leading: CGFloat,
+    rowHeight: CGFloat
+) -> LineFragment {
+    LineFragment(
+        start: start,
+        end: end,
+        paintEnd: end,
+        fitWidth: spanWidth,
+        paintWidth: spanWidth,
+        trailingWhitespaceWidth: 0,
+        ascent: ascent,
+        descent: descent,
+        leading: leading,
+        blockAdvance: rowHeight
+    )
+}
+
+private func preparedObstacleCoordinateDisplayFrame(
+    originX: CGFloat,
+    originY: CGFloat,
+    lineWidth: CGFloat,
+    fragment: LineFragment
+) -> CGRect {
+    let typographicTop = originY + fragment.paragraphSpacingBefore
+    let typographicHeight = max(fragment.ascent + fragment.descent + fragment.leading, 1)
+    return CGRect(x: originX, y: typographicTop, width: lineWidth, height: typographicHeight)
+}
+
+private func preparedObstacleCoordinateRect(
+    for displayUTF16Range: NSRange,
+    ctLine: CTLine,
+    originX: CGFloat,
+    originY: CGFloat,
+    lineWidth: CGFloat,
+    fragment: LineFragment
+) -> CGRect? {
+    guard displayUTF16Range.length > 0 else {
+        return nil
+    }
+
+    let lineLength = CTLineGetStringRange(ctLine).length
+    let displayEnd = min(NSMaxRange(displayUTF16Range), lineLength)
+    let displayStart = min(max(displayUTF16Range.location, 0), displayEnd)
+    guard displayEnd > displayStart else {
+        return nil
+    }
+
+    let localStart = CGFloat(CTLineGetOffsetForStringIndex(ctLine, displayStart, nil))
+    let localEnd: CGFloat
+    if displayEnd >= lineLength {
+        localEnd = lineWidth
+    } else {
+        localEnd = CGFloat(CTLineGetOffsetForStringIndex(ctLine, displayEnd, nil))
+    }
+
+    let rect = preparedObstacleCoordinateDisplayFrame(
+        originX: originX + min(localStart, localEnd),
+        originY: originY,
+        lineWidth: max(localEnd - localStart, 0),
+        fragment: fragment
+    )
+    return rect.isNull || rect.isEmpty ? nil : rect
+}
+
+private func preparedObstacleCoordinateSpans(
+    attributedText: NSAttributedString,
+    sourceUTF16Range: NSRange,
+    mappingMode: PreparedTextSourceCoordinateMappingMode,
+    ctLine: CTLine,
+    originX: CGFloat,
+    originY: CGFloat,
+    lineWidth: CGFloat,
+    fragment: LineFragment
+) -> [PreparedTextSourceCoordinateSpan] {
+    let displayRange = NSRange(location: 0, length: attributedText.length)
+    guard displayRange.length > 0 else {
+        return []
+    }
+
+    guard mappingMode == .exact, sourceUTF16Range.length == displayRange.length else {
+        return [
+            PreparedTextSourceCoordinateSpan(
+                displayUTF16Range: displayRange,
+                sourceUTF16Range: sourceUTF16Range,
+                displayRect: preparedObstacleCoordinateRect(
+                    for: displayRange,
+                    ctLine: ctLine,
+                    originX: originX,
+                    originY: originY,
+                    lineWidth: lineWidth,
+                    fragment: fragment
+                )
+            ),
+        ]
+    }
+
+    let string = attributedText.string as NSString
+    var spans: [PreparedTextSourceCoordinateSpan] = []
+    var index = 0
+    while index < string.length {
+        let localRange = string.rangeOfComposedCharacterSequence(at: index)
+        let sourceRange = NSRange(
+            location: sourceUTF16Range.location + localRange.location,
+            length: localRange.length
+        )
+        spans.append(
+            PreparedTextSourceCoordinateSpan(
+                displayUTF16Range: localRange,
+                sourceUTF16Range: sourceRange,
+                displayRect: preparedObstacleCoordinateRect(
+                    for: localRange,
+                    ctLine: ctLine,
+                    originX: originX,
+                    originY: originY,
+                    lineWidth: lineWidth,
+                    fragment: fragment
+                )
+            )
+        )
+        index = NSMaxRange(localRange)
+    }
+
+    return spans
 }

--- a/Sources/PretextValidation/main.swift
+++ b/Sources/PretextValidation/main.swift
@@ -614,6 +614,40 @@ struct ValidationSuite {
             try expect(visibleRects.allSatisfy(\.isExact), "expected visible literal link rects to stay exact")
         }
 
+        execute("rtl-coordinate-map-rect-queries-stay-visible") {
+            let attributed = NSMutableAttributedString(
+                string: "مرحبا بالعالم",
+                attributes: [kCTFontAttributeName as NSAttributedString.Key: CTFontCreateWithName("Helvetica" as CFString, 19, nil)]
+            )
+            let worldRange = (attributed.string as NSString).range(of: "بالعالم")
+            attributed.addAttribute(.link, value: URL(string: "https://example.com/world")!, range: worldRange)
+
+            let prepared = engine.prepare(
+                attributed,
+                sourceID: PreparedTextSourceID("validation-rtl-coordinate-rects"),
+                options: PreparedTextOptions(whiteSpaceMode: .uikitLiteral)
+            )
+            let packet = engine.displayLayoutPacket(
+                prepared,
+                maxWidth: 220,
+                lineHeight: prepared.defaultLineHeight,
+                containerWidth: 220,
+                env: .default,
+                options: PreparedTextLayoutOptions(
+                    maximumNumberOfLines: 1,
+                    lineBreakMode: .wordWrap,
+                    alignment: .right,
+                    layoutDirection: .rightToLeft
+                )
+            )
+
+            let rects = packet.sourceCoordinateMap.displayedRects(forSourceUTF16Range: worldRange)
+
+            try expect(rects.isEmpty == false, "expected visible rects for right-to-left source ranges")
+            try expect(rects.contains { $0.rect.width > 0 }, "expected right-to-left rect query to preserve positive width")
+            try expect(rects.allSatisfy(\.isExact), "expected literal right-to-left rect queries to remain exact")
+        }
+
 #if canImport(PretextUIKit)
         execute("obstacle-layout-exposes-public-visible-structure") {
             let system = PreparedTextSystem(

--- a/Sources/PretextValidation/main.swift
+++ b/Sources/PretextValidation/main.swift
@@ -118,6 +118,37 @@ struct ValidationSuite {
             }
         }
 
+        func mergedRanges(_ ranges: [NSRange]) -> [NSRange] {
+            guard ranges.isEmpty == false else {
+                return []
+            }
+
+            let sorted = ranges.sorted {
+                if $0.location == $1.location {
+                    return $0.length < $1.length
+                }
+                return $0.location < $1.location
+            }
+
+            var merged: [NSRange] = []
+            for range in sorted {
+                guard var last = merged.last else {
+                    merged.append(range)
+                    continue
+                }
+
+                let lastEnd = NSMaxRange(last)
+                if range.location <= lastEnd {
+                    last.length = max(lastEnd, NSMaxRange(range)) - last.location
+                    merged[merged.count - 1] = last
+                } else {
+                    merged.append(range)
+                }
+            }
+
+            return merged
+        }
+
         execute("stage0-cache-hit") {
             let measurer = CachedFramesetterTextMeasurer()
             let text = fixtureText("Cache me if you can.")
@@ -346,7 +377,8 @@ struct ValidationSuite {
             try expect(packet.result.stoppedEarlyAtMaximumNumberOfLines, "expected single-line layout to stop early")
             try expect(packet.lines.first?.isTruncated == true, "expected visible line to carry truncation state")
             try expect(packet.result.visibleSourceUTF16Ranges.count == 1, "expected a single visible source range for tail truncation")
-            try expect(packet.sourceCoordinateMap.lines.first?.visibleSourceUTF16Ranges.count == 1, "expected source coordinate map to preserve the visible range")
+            let mappedRanges = mergedRanges(packet.sourceCoordinateMap.lines.first?.visibleSourceUTF16Ranges ?? [])
+            try expect(mappedRanges == packet.result.visibleSourceUTF16Ranges, "expected source coordinate map to preserve the visible range")
         }
 
         execute("word-wrap-line-limit-still-reports-hidden-overflow") {
@@ -433,6 +465,7 @@ struct ValidationSuite {
         execute("attachment-spans-report-placeholder-vs-resolved-state") {
             let registry = PreparedAttachmentRegistry()
             let attachmentID = PreparedAttachmentID("validation-attachment")
+            let sourceID = PreparedTextSourceID("validation-attachment-source")
             let engine = DefaultPreparedTextEngine(
                 measurer: CachedFramesetterTextMeasurer(),
                 attachmentResolver: registry
@@ -452,27 +485,41 @@ struct ValidationSuite {
 
             let placeholderPrepared = engine.prepare(
                 attributed,
-                sourceID: PreparedTextSourceID("validation-attachment-source"),
+                sourceID: sourceID,
                 options: PreparedTextOptions(whiteSpaceMode: .uikitLiteral)
             )
             try expect(placeholderPrepared.attachmentSpans.count == 1, "expected one attachment span in placeholder state")
             try expect(placeholderPrepared.attachmentSpans.first?.isResolved == false, "expected placeholder attachment span to stay unresolved")
+            try expect(
+                registry.attachmentState(for: attachment.reference) == .placeholder(attachment.reference),
+                "expected registry to expose placeholder attachment lifecycle"
+            )
 
-            registry.setResolvedAttachment(
-                PreparedResolvedAttachment(
-                    bounds: CGRect(x: 0, y: 0, width: 24, height: 16),
-                    contentIdentity: "validation@2x"
+            registry.setAttachmentState(
+                .resolved(
+                    attachment.reference,
+                    PreparedResolvedAttachment(
+                        bounds: CGRect(x: 0, y: 0, width: 24, height: 16),
+                        contentIdentity: "validation@2x"
+                    )
                 ),
-                for: attachmentID,
                 invalidate: []
             )
             let resolvedPrepared = engine.prepare(
                 attributed,
-                sourceID: PreparedTextSourceID("validation-attachment-source"),
+                sourceID: sourceID,
                 options: PreparedTextOptions(whiteSpaceMode: .uikitLiteral)
             )
             try expect(resolvedPrepared.attachmentSpans.first?.isResolved == true, "expected resolved attachment span after registry update")
             try expectEqual(resolvedPrepared.attachmentSpans.first?.resolvedContentIdentity, "validation@2x", "expected resolved content identity")
+            try expect(
+                registry.attachmentState(for: attachment.reference).resolvedAttachment?.contentIdentity == "validation@2x",
+                "expected resolver lifecycle to expose resolved content identity"
+            )
+            try expect(
+                registry.recordedSourceIDs(for: attachmentID).contains(sourceID),
+                "expected registry to retain targeted source invalidation usage"
+            )
         }
 
         execute("visible-tokens-follow-truncated-coordinate-map") {
@@ -522,8 +569,49 @@ struct ValidationSuite {
             )
 
             let spans = packet.sourceCoordinateMap.displayedSpans(forSourceUTF16Range: NSRange(location: 0, length: 3))
+            let rects = packet.sourceCoordinateMap.displayedRects(forSourceUTF16Range: NSRange(location: 0, length: 3))
             try expect(packet.sourceCoordinateMap.mappingMode == .bestEffort, "expected css-normal mapping to be best-effort")
             try expect(spans.isEmpty == false, "expected best-effort coordinate mapping to still expose display spans")
+            try expect(rects.isEmpty == false, "expected best-effort coordinate mapping to still expose visible rects")
+            try expect(rects.allSatisfy { $0.isExact == false }, "expected best-effort coordinate rects to remain explicitly inexact")
+        }
+
+        execute("coordinate-map-rect-queries-follow-visible-link-geometry") {
+            let attributed = NSMutableAttributedString(
+                string: "Visible #first\nHidden second link",
+                attributes: [kCTFontAttributeName as NSAttributedString.Key: CTFontCreateWithName("Helvetica" as CFString, 17, nil)]
+            )
+            let visibleRange = (attributed.string as NSString).range(of: "#first")
+            let hiddenRange = (attributed.string as NSString).range(of: "second link")
+            attributed.addAttribute(.link, value: URL(string: "https://example.com/visible")!, range: visibleRange)
+            attributed.addAttribute(.link, value: URL(string: "https://example.com/hidden")!, range: hiddenRange)
+
+            let prepared = engine.prepare(
+                attributed,
+                sourceID: PreparedTextSourceID("validation-coordinate-rects"),
+                options: PreparedTextOptions(whiteSpaceMode: .uikitLiteral)
+            )
+            let packet = engine.displayLayoutPacket(
+                prepared,
+                maxWidth: 180,
+                lineHeight: prepared.defaultLineHeight,
+                containerWidth: 180,
+                env: .default,
+                options: PreparedTextLayoutOptions(
+                    maximumNumberOfLines: 1,
+                    lineBreakMode: .truncateTail,
+                    alignment: .left,
+                    layoutDirection: .leftToRight
+                )
+            )
+
+            let visibleLink = packet.visibleAnnotations(in: prepared).first(where: { $0.kind == .link })
+            let visibleRects = visibleLink.map(packet.sourceCoordinateMap.displayedRects(for:)) ?? []
+            let hiddenRects = packet.sourceCoordinateMap.displayedRects(forSourceUTF16Range: hiddenRange)
+
+            try expect(visibleRects.isEmpty == false, "expected visible link rects from the public coordinate map")
+            try expect(hiddenRects.isEmpty == true, "expected hidden link rects to stay excluded after truncation")
+            try expect(visibleRects.allSatisfy(\.isExact), "expected visible literal link rects to stay exact")
         }
 
 #if canImport(PretextUIKit)
@@ -560,6 +648,8 @@ struct ValidationSuite {
             let map = result.sourceCoordinateMap(in: prepared)
             let visibleTokens = result.visibleTokens(in: prepared)
             let visibleAnnotations = result.visibleAnnotations(in: prepared)
+            let hashtag = visibleTokens.first(where: { $0.kind == .hashtag })
+            let hashtagRects = hashtag.map { map.displayedRects(for: $0) } ?? []
 
             try expect(result.fragments.isEmpty == false, "expected obstacle layout to emit visible fragments")
             try expect(result.snapshot.obstacleCount == 1, "expected obstacle snapshot to report the public obstacle count")
@@ -567,6 +657,48 @@ struct ValidationSuite {
             try expect(visibleTokens.contains(where: { $0.kind == .mention }), "expected visible mention token through obstacle layout")
             try expect(visibleTokens.contains(where: { $0.kind == .hashtag }), "expected visible hashtag token through obstacle layout")
             try expect(visibleAnnotations.contains(where: { $0.kind == .link }), "expected visible link annotation through obstacle layout")
+            try expect(hashtagRects.isEmpty == false, "expected obstacle layout to expose visible rects for hashtag tokens")
+        }
+
+        execute("rounded-rect-obstacle-layout-exposes-public-visible-structure") {
+            let system = PreparedTextSystem(
+                measurer: CachedFramesetterTextMeasurer(),
+                invalidationCenter: PreparedInvalidationCenter()
+            )
+            let layouter = PreparedTextObstacleLayouter(textSystem: system)
+            let attributed = NSMutableAttributedString(
+                string: "Rounded panels keep #prepared and @ops readable while a note block trims the middle rows.",
+                attributes: [kCTFontAttributeName as NSAttributedString.Key: CTFontCreateWithName("Helvetica" as CFString, 17, nil)]
+            )
+            let hashtagRange = (attributed.string as NSString).range(of: "#prepared")
+            let prepared = system.prepare(
+                attributed,
+                sourceID: PreparedTextSourceID("validation-rounded-obstacle"),
+                options: PreparedTextOptions(whiteSpaceMode: .uikitLiteral)
+            )
+
+            let result = layouter.layout(
+                prepared: prepared,
+                in: CGRect(x: 0, y: 0, width: 260, height: 180),
+                obstacles: [
+                    PreparedObstacle(
+                        roundedRect: PreparedTextObstacleRoundedRect(
+                            rect: CGRect(x: 132, y: 44, width: 88, height: 86),
+                            cornerRadius: 20
+                        )
+                    ),
+                ],
+                lineHeight: prepared.defaultLineHeight,
+                obstaclePadding: 10,
+                minimumSpanWidth: 30
+            )
+
+            let map = result.sourceCoordinateMap(in: prepared)
+            let rects = map.displayedRects(forSourceUTF16Range: hashtagRange)
+            try expect(result.fragments.isEmpty == false, "expected rounded-rect obstacle layout to emit visible fragments")
+            try expect(result.preparedObstacles.first?.roundedRect != nil, "expected public obstacle result to preserve rounded-rect metadata")
+            try expect(result.snapshot.splitRowCount > 0, "expected rounded-rect obstacle to split at least one row")
+            try expect(rects.isEmpty == false, "expected coordinate map rects through rounded-rect obstacle layout")
         }
 #endif
 

--- a/Tests/PretextCoreTests/PretextCoreTests.swift
+++ b/Tests/PretextCoreTests/PretextCoreTests.swift
@@ -619,6 +619,40 @@ final class PretextCoreTests: XCTestCase {
         XCTAssertEqual(packet.sourceCoordinateMap.displayedRects(forSourceUTF16Range: firstWordRange).first?.isExact, false)
     }
 
+    func testSourceCoordinateMapKeepsVisibleRectsForRightToLeftRanges() {
+        let attributed = NSMutableAttributedString(
+            string: "مرحبا بالعالم",
+            attributes: [kCTFontAttributeName as NSAttributedString.Key: CTFontCreateWithName("Helvetica" as CFString, 19, nil)]
+        )
+        let worldRange = (attributed.string as NSString).range(of: "بالعالم")
+        attributed.addAttribute(.link, value: URL(string: "https://example.com/world")!, range: worldRange)
+
+        let engine = DefaultPreparedTextEngine()
+        let prepared = engine.prepare(
+            attributed,
+            sourceID: PreparedTextSourceID("rtl-coordinate-rects"),
+            options: PreparedTextOptions(whiteSpaceMode: .uikitLiteral)
+        )
+        let packet = engine.displayLayoutPacket(
+            prepared,
+            maxWidth: 220,
+            lineHeight: prepared.defaultLineHeight,
+            containerWidth: 220,
+            options: PreparedTextLayoutOptions(
+                maximumNumberOfLines: 1,
+                lineBreakMode: .wordWrap,
+                alignment: .right,
+                layoutDirection: .rightToLeft
+            )
+        )
+
+        let rects = packet.sourceCoordinateMap.displayedRects(forSourceUTF16Range: worldRange)
+
+        XCTAssertFalse(rects.isEmpty)
+        XCTAssertTrue(rects.contains { $0.rect.width > 0 })
+        XCTAssertTrue(rects.allSatisfy(\.isExact))
+    }
+
     func testCoreLayoutPacketTreatsUnlimitedMaximumNumberOfLinesAsUnlimited() {
         let engine = DefaultPreparedTextEngine()
         let prepared = engine.prepare(

--- a/Tests/PretextCoreTests/PretextCoreTests.swift
+++ b/Tests/PretextCoreTests/PretextCoreTests.swift
@@ -330,11 +330,11 @@ final class PretextCoreTests: XCTestCase {
         XCTAssertTrue(packet.lines[0].isTruncated)
         XCTAssertTrue(packet.lines[0].attributedText.string.contains("…"))
         XCTAssertEqual(packet.sourceCoordinateMap.lines.count, 1)
-        XCTAssertEqual(packet.sourceCoordinateMap.lines[0].sourceSpans.count, 3)
-        XCTAssertEqual(packet.sourceCoordinateMap.lines[0].sourceSpans.filter { $0.sourceUTF16Range == nil }.count, 1)
+        XCTAssertGreaterThan(packet.sourceCoordinateMap.lines[0].sourceSpans.count, 3)
+        XCTAssertGreaterThanOrEqual(packet.sourceCoordinateMap.lines[0].sourceSpans.filter { $0.sourceUTF16Range == nil }.count, 1)
         XCTAssertEqual(
-            packet.sourceCoordinateMap.lines[0].visibleSourceUTF16Ranges.count,
-            2
+            packet.sourceCoordinateMap.lines[0].visibleSourceUTF16Ranges.reduce(0) { $0 + $1.length },
+            packet.result.visibleSourceUTF16Ranges.reduce(0) { $0 + $1.length }
         )
     }
 
@@ -379,6 +379,49 @@ final class PretextCoreTests: XCTestCase {
         XCTAssertEqual(resolvedSpan?.resolvedBounds, CGRect(x: 0, y: 0, width: 26, height: 18))
         XCTAssertEqual(resolvedSpan?.resolvedContentIdentity, "phase3@2x")
         XCTAssertTrue(resolvedSpan?.isResolved ?? false)
+    }
+
+    @MainActor
+    func testPreparedAttachmentResolverLifecycleTracksRecordedSources() async {
+        let center = PreparedInvalidationCenter()
+        let registry = PreparedAttachmentRegistry(invalidationCenter: center)
+        let system = PreparedTextSystem(
+            measurer: CachedFramesetterTextMeasurer(),
+            invalidationCenter: center,
+            attachmentResolver: registry
+        )
+        let attachmentID = PreparedAttachmentID("round1-attachment")
+        let sourceID = PreparedTextSourceID("round1-attachment-source")
+        let reference = PreparedAttachmentReference(
+            id: attachmentID,
+            placeholderBounds: CGRect(x: 0, y: 0, width: 14, height: 12)
+        )
+
+        let prepared = system.prepare(
+            referencedAttachmentText(id: attachmentID, placeholderBounds: reference.placeholderBounds),
+            sourceID: sourceID,
+            options: PreparedTextOptions(whiteSpaceMode: .uikitLiteral)
+        )
+        _ = system.layoutPacket(prepared, maxWidth: 160, lineHeight: prepared.defaultLineHeight, env: .default)
+
+        XCTAssertEqual(registry.attachmentState(for: reference), .placeholder(reference))
+        XCTAssertEqual(registry.recordedSourceIDs(for: attachmentID), [sourceID])
+
+        let resolved = PreparedResolvedAttachment(
+            bounds: CGRect(x: 0, y: 0, width: 28, height: 18),
+            contentIdentity: "round1@2x"
+        )
+        registry.setAttachmentState(.resolved(reference, resolved))
+        await settleInvalidation()
+
+        XCTAssertEqual(registry.attachmentState(for: reference), .resolved(reference, resolved))
+        XCTAssertEqual(system.diagnosticsSnapshot().invalidations.targetedInvalidationCount, 1)
+
+        registry.setAttachmentState(.placeholder(reference))
+        await settleInvalidation()
+
+        XCTAssertEqual(registry.attachmentState(for: reference), .placeholder(reference))
+        XCTAssertEqual(system.diagnosticsSnapshot().invalidations.targetedInvalidationCount, 2)
     }
 
     func testPreparedTextExposesDeterministicTokensAndAnnotations() {
@@ -496,15 +539,63 @@ final class PretextCoreTests: XCTestCase {
         let alphaRange = (prepared.source.string as NSString).range(of: "Alpha")
         let spans = packet.sourceCoordinateMap.displayedSpans(forSourceUTF16Range: alphaRange)
         XCTAssertEqual(packet.sourceCoordinateMap.mappingMode, .exact)
-        XCTAssertEqual(spans.count, 1)
-        XCTAssertEqual(spans.first?.displayUTF16Range.length, spans.first?.sourceUTF16Range?.length)
+        XCTAssertFalse(spans.isEmpty)
+        XCTAssertLessThanOrEqual(spans.compactMap(\.sourceUTF16Range).reduce(0) { $0 + $1.length }, alphaRange.length)
+        XCTAssertTrue(spans.allSatisfy(\.isExact))
         XCTAssertEqual(
             packet.sourceCoordinateMap.sourceUTF16Ranges(
                 forDisplayedUTF16Range: spans[0].displayUTF16Range,
                 onLine: spans[0].lineIndex
             ),
-            spans.compactMap(\.sourceUTF16Range)
+            spans[0].sourceUTF16Range.map { [$0] } ?? []
         )
+    }
+
+    func testSourceCoordinateMapExposesVisibleRectsForAnnotationsAndTokens() {
+        let attributed = NSMutableAttributedString(
+            string: "Visible #first\nHidden second link",
+            attributes: [kCTFontAttributeName as NSAttributedString.Key: CTFontCreateWithName("Helvetica" as CFString, 17, nil)]
+        )
+        let visibleRange = (attributed.string as NSString).range(of: "#first")
+        let hiddenRange = (attributed.string as NSString).range(of: "second link")
+        attributed.addAttribute(.link, value: URL(string: "https://example.com/visible")!, range: visibleRange)
+        attributed.addAttribute(.link, value: URL(string: "https://example.com/hidden")!, range: hiddenRange)
+
+        let engine = DefaultPreparedTextEngine()
+        let prepared = engine.prepare(
+            attributed,
+            sourceID: PreparedTextSourceID("round1-coordinate-rects"),
+            options: PreparedTextOptions(whiteSpaceMode: .uikitLiteral)
+        )
+        let packet = engine.displayLayoutPacket(
+            prepared,
+            maxWidth: 180,
+            lineHeight: prepared.defaultLineHeight,
+            containerWidth: 180,
+            options: PreparedTextLayoutOptions(
+                maximumNumberOfLines: 1,
+                lineBreakMode: .truncateTail,
+                alignment: .left,
+                layoutDirection: .leftToRight
+            )
+        )
+        let map = packet.sourceCoordinateMap
+        let visibleLink = try? XCTUnwrap(packet.visibleAnnotations(in: prepared).first(where: { $0.kind == .link }))
+        let visibleToken = try? XCTUnwrap(packet.visibleTokens(in: prepared).first(where: { $0.kind == .hashtag }))
+
+        let visibleLinkRects = visibleLink.map(map.displayedRects(for:)) ?? []
+        let visibleTokenRects = visibleToken.map(map.displayedRects(for:)) ?? []
+        let hiddenRects = map.displayedRects(forSourceUTF16Range: hiddenRange)
+        let lineSourceRanges = map.sourceUTF16Ranges(onDisplayedLine: 0)
+
+        XCTAssertEqual(map.lines.count, 1)
+        XCTAssertEqual(lineSourceRanges.first, NSRange(location: 0, length: 1))
+        XCTAssertEqual(lineSourceRanges.reduce(0) { $0 + $1.length }, map.visibleSourceUTF16Ranges.reduce(0) { $0 + $1.length })
+        XCTAssertFalse(visibleLinkRects.isEmpty)
+        XCTAssertFalse(visibleTokenRects.isEmpty)
+        XCTAssertFalse(visibleLinkRects[0].rect.isEmpty)
+        XCTAssertTrue(visibleLinkRects[0].isExact)
+        XCTAssertTrue(hiddenRects.isEmpty)
     }
 
     func testCSSNormalCoordinateMapReportsBestEffortMode() {
@@ -525,6 +616,7 @@ final class PretextCoreTests: XCTestCase {
         XCTAssertEqual(prepared.sourceCoordinateMappingMode, .bestEffort)
         XCTAssertEqual(packet.sourceCoordinateMap.mappingMode, .bestEffort)
         XCTAssertFalse(packet.sourceCoordinateMap.displayedSpans(forSourceUTF16Range: firstWordRange).isEmpty)
+        XCTAssertEqual(packet.sourceCoordinateMap.displayedRects(forSourceUTF16Range: firstWordRange).first?.isExact, false)
     }
 
     func testCoreLayoutPacketTreatsUnlimitedMaximumNumberOfLinesAsUnlimited() {

--- a/Tests/PretextUIKitTests/PreparedTextUIKitTests.swift
+++ b/Tests/PretextUIKitTests/PreparedTextUIKitTests.swift
@@ -863,6 +863,36 @@ final class PreparedTextUIKitTests: XCTestCase {
         XCTAssertFalse(rects[0].rect.isEmpty)
     }
 
+    func testPreparedTextObstacleLayouterKeepsVisibleRectsForRightToLeftRanges() {
+        let attributed = NSMutableAttributedString(
+            string: "بطاقات العوائق تحافظ على الروابط المرئية",
+            attributes: [.font: UIFont.systemFont(ofSize: 19)]
+        )
+        let linkRange = (attributed.string as NSString).range(of: "الروابط")
+        attributed.addAttribute(.link, value: URL(string: "https://example.com/links")!, range: linkRange)
+
+        let prepared = PreparedTextSystem.shared.prepare(
+            attributed,
+            sourceID: PreparedTextSourceID("ios-obstacle-rtl-rects")
+        )
+        let layouter = PreparedTextObstacleLayouter(textSystem: .shared)
+        let result = layouter.layout(
+            prepared: prepared,
+            in: CGRect(x: 24, y: 24, width: 272, height: 220),
+            obstacles: [
+                PreparedObstacle(circle: PreparedTextObstacleCircle(center: CGPoint(x: 160, y: 96), radius: 34)),
+            ],
+            lineHeight: prepared.defaultLineHeight,
+            obstaclePadding: 10,
+            minimumSpanWidth: 30
+        )
+
+        let rects = result.sourceCoordinateMap(in: prepared).displayedRects(forSourceUTF16Range: linkRange)
+
+        XCTAssertFalse(rects.isEmpty)
+        XCTAssertTrue(rects.contains { $0.rect.width > 0 })
+    }
+
     func testObstacleDemoPreservesHardBreakAcrossSplitRows() {
         let view = PreparedTextObstacleDemoView()
         view.apply(

--- a/Tests/PretextUIKitTests/PreparedTextUIKitTests.swift
+++ b/Tests/PretextUIKitTests/PreparedTextUIKitTests.swift
@@ -524,7 +524,8 @@ final class PreparedTextUIKitTests: XCTestCase {
 
         let map = view.sourceCoordinateMap()
         XCTAssertEqual(map?.lines.count, 1)
-        XCTAssertEqual(map?.lines.first?.sourceSpans.count, 3)
+        XCTAssertGreaterThan(map?.lines.first?.sourceSpans.count ?? 0, 3)
+        XCTAssertFalse(map?.lines.first?.visibleSourceUTF16Ranges.isEmpty ?? true)
         XCTAssertTrue(map?.lines.first?.isTruncated ?? false)
     }
 
@@ -588,6 +589,8 @@ final class PreparedTextUIKitTests: XCTestCase {
         let size = view.sizeThatFits(CGSize(width: 220, height: CGFloat.greatestFiniteMagnitude))
         view.frame = CGRect(x: 0, y: 0, width: 220, height: size.height)
 
+        XCTAssertTrue(view.isAccessibilityElement)
+        XCTAssertNil(view.accessibilityElements)
         XCTAssertEqual(view.accessibilityCustomActions?.count, 1)
         XCTAssertEqual(view.accessibilityCustomActions?.first?.name, "Visible")
         XCTAssertTrue(view.accessibilityActivate())
@@ -622,8 +625,60 @@ final class PreparedTextUIKitTests: XCTestCase {
         let size = view.sizeThatFits(CGSize(width: 220, height: CGFloat.greatestFiniteMagnitude))
         view.frame = CGRect(x: 0, y: 0, width: 220, height: size.height)
 
+        XCTAssertTrue(view.isAccessibilityElement)
+        XCTAssertNil(view.accessibilityElements)
         XCTAssertEqual(view.accessibilityCustomActions?.count, 1)
         XCTAssertEqual(view.accessibilityCustomActions?.first?.name, "Visible")
+    }
+
+    func testPreparedLabelViewPromotesMultipleVisibleLinksToAccessibilityElements() throws {
+        let firstURL = URL(string: "https://example.com/first-link")!
+        let secondURL = URL(string: "https://example.com/second-link")!
+        let attributed = NSMutableAttributedString(
+            string: "First link and second link stay individually focusable.",
+            attributes: [.font: UIFont.systemFont(ofSize: 17)]
+        )
+        let firstRange = (attributed.string as NSString).range(of: "First link")
+        let secondRange = (attributed.string as NSString).range(of: "second link")
+        attributed.addAttribute(.link, value: firstURL, range: firstRange)
+        attributed.addAttribute(.link, value: secondURL, range: secondRange)
+
+        let expectation = expectation(description: "both accessibility links activated")
+        expectation.expectedFulfillmentCount = 2
+        var activatedURLs: [URL] = []
+
+        let view = PreparedLabelView()
+        view.apply(
+            configuration: PreparedLabelConfiguration(
+                attributedText: attributed,
+                sourceID: PreparedTextSourceID("ios-accessibility-multiple-links"),
+                whiteSpaceMode: .uikitLiteral,
+                maxLayoutWidth: 260,
+                automaticallyOpensLinks: false,
+                linkTapHandler: { tappedURL in
+                    activatedURLs.append(tappedURL)
+                    expectation.fulfill()
+                }
+            )
+        )
+
+        let size = view.sizeThatFits(CGSize(width: 260, height: CGFloat.greatestFiniteMagnitude))
+        view.frame = CGRect(x: 0, y: 0, width: 260, height: size.height)
+        view.layoutIfNeeded()
+
+        XCTAssertFalse(view.isAccessibilityElement)
+        let elements = try XCTUnwrap(view.accessibilityElements as? [UIAccessibilityElement])
+        XCTAssertEqual(elements.count, 3)
+        XCTAssertEqual(elements[0].accessibilityLabel, attributed.string)
+        XCTAssertEqual(elements[1].accessibilityLabel, "First link")
+        XCTAssertEqual(elements[2].accessibilityLabel, "second link")
+        XCTAssertFalse(elements[1].accessibilityFrameInContainerSpace.isEmpty)
+        XCTAssertFalse(elements[2].accessibilityFrameInContainerSpace.isEmpty)
+        XCTAssertTrue(elements[1].accessibilityActivate())
+        XCTAssertTrue(elements[2].accessibilityActivate())
+
+        wait(for: [expectation], timeout: 1)
+        XCTAssertEqual(activatedURLs, [firstURL, secondURL])
     }
 
     func testPreparedLabelViewTapGestureDoesNotCancelTouchesInView() throws {
@@ -762,11 +817,50 @@ final class PreparedTextUIKitTests: XCTestCase {
 
         let map = result.sourceCoordinateMap(in: prepared)
         let tokens = result.visibleTokens(in: prepared)
+        let hashtag = tokens.first(where: { $0.kind == .hashtag })
+        let hashtagRects = hashtag.map { map.displayedRects(for: $0) } ?? []
 
         XCTAssertEqual(map.lines.count, result.fragments.count)
         XCTAssertEqual(result.snapshot.obstacleCount, 1)
         XCTAssertTrue(tokens.contains { $0.kind == .hashtag })
         XCTAssertTrue(tokens.contains { $0.kind == .mention })
+        XCTAssertFalse(hashtagRects.isEmpty)
+        XCTAssertTrue(hashtagRects.contains { $0.rect.isEmpty == false })
+    }
+
+    func testPreparedTextObstacleLayouterSupportsRoundedRectObstacles() {
+        let prepared = PreparedTextSystem.shared.prepare(
+            text("Rounded exclusion cards should keep #prepared and @team visible while a wide panel trims the middle rows."),
+            sourceID: PreparedTextSourceID("ios-obstacle-rounded-rect")
+        )
+        let layouter = PreparedTextObstacleLayouter(textSystem: .shared)
+        let result = layouter.layout(
+            prepared: prepared,
+            in: CGRect(x: 24, y: 24, width: 272, height: 220),
+            obstacles: [
+                PreparedObstacle(
+                    roundedRect: PreparedTextObstacleRoundedRect(
+                        rect: CGRect(x: 132, y: 70, width: 88, height: 92),
+                        cornerRadius: 22
+                    )
+                ),
+            ],
+            lineHeight: prepared.defaultLineHeight,
+            obstaclePadding: 10,
+            minimumSpanWidth: 30
+        )
+
+        let map = result.sourceCoordinateMap(in: prepared)
+        let hashtagRange = (prepared.source.string as NSString).range(of: "#prepared")
+        let rects = map.displayedRects(forSourceUTF16Range: hashtagRange)
+
+        XCTAssertEqual(result.snapshot.obstacleCount, 1)
+        XCTAssertGreaterThan(result.snapshot.rowCount, 0)
+        XCTAssertGreaterThan(result.snapshot.fragmentCount, 0)
+        XCTAssertTrue(result.snapshot.splitRowCount > 0)
+        XCTAssertNotNil(result.preparedObstacles.first?.roundedRect)
+        XCTAssertFalse(rects.isEmpty)
+        XCTAssertFalse(rects[0].rect.isEmpty)
     }
 
     func testObstacleDemoPreservesHardBreakAcrossSplitRows() {

--- a/docs/Benchmarks.md
+++ b/docs/Benchmarks.md
@@ -11,7 +11,7 @@ prepared-text-ios keeps a host-side benchmark runner for the prepared-text hot p
 - list-style batch sizing with public layout options
 - prepared token / annotation extraction cost
 - source/display coordinate-map query cost
-- circle-obstacle layout sweep on top of prepared text
+- circle and rounded-rect obstacle-layout sweeps on top of prepared text
 
 ## Run
 
@@ -51,7 +51,7 @@ These benchmarks run as a host-side SwiftPM CLI on macOS. They are useful for:
 - URL-heavy policy comparisons through line-break strategy sweeps
 - cache reuse sanity checks through hit rate and cache-cost indicators
 - prepared representation extraction cost for token / annotation / coordinate-map queries
-- obstacle-layout cost on repeated-width prepared text around circle exclusion zones
+- obstacle-layout cost on repeated-width prepared text around circle and rounded-rect exclusion zones
 
 They are not a replacement for profiling on the final iOS app or device.
 
@@ -64,7 +64,7 @@ Read the report with these rules:
 - line-limited rows matter because Phase 2 moved max-lines and truncation ownership into the core engine
 - `url-friendly` and `native-typesetter` strategy rows are narrow supported policies, not browser-grade guarantees
 - prepared representation rows should stay cheap enough for inspection, hit-testing scaffolding, and analytics-style queries on already prepared packets
-- obstacle-layout rows are intentionally narrow and should be read as circle-exclusion layout costs, not as a general document-layout benchmark
+- obstacle-layout rows are intentionally narrow and should be read as circle / rounded-rect exclusion layout costs, not as a general document-layout benchmark
 
 ## Release usage
 

--- a/docs/KnownGaps.md
+++ b/docs/KnownGaps.md
@@ -27,7 +27,7 @@ This repository is positioned as a **stable** library release for its documented
 - `PreparedLabelView` supports line limits, truncation, alignment, line-break strategy selection, and read-only link activation, but it is still not a full `UILabel` replacement.
 - The promoted `PreparedTextLayoutOptions` surface intentionally covers line limits, truncation, alignment, line-break strategy, and layout direction only. It is not a full paragraph layout or editing framework.
 - `PreparedToken`, `PreparedAnnotation`, and `PreparedAttachmentSpan` are narrow inspection surfaces for read-only prepared content. They are not a syntax highlighting system, generalized parser, or authoring-time annotation model.
-- Link accessibility is exposed for read-only content, but multiple links inside one label are surfaced as custom accessibility actions rather than distinct accessibility elements.
+- `PreparedLabelView` now promotes multiple visible links to distinct accessibility elements when the prepared coordinate map can form stable visible rects. Container-level custom actions remain as a fallback when safe per-link geometry cannot be produced.
 - `PreparedTextView` is a UIKit bridge. It does not replace native SwiftUI `Text` internals.
 - `UILabel().prepared()` and global legacy UILabel support are Stage 0 sizing helpers only. They do not swap UILabel drawing for the Stage 1 renderer.
 - `PreparedTextLegacySupport.installUILabelSupport(...)` should be treated as a main-thread app setup step. It is explicit runtime adoption, not import-time behavior.
@@ -35,14 +35,14 @@ This repository is positioned as a **stable** library release for its documented
 - UILabel subclasses that heavily override sizing behavior may not automatically benefit from the base-class swizzled Stage 0 adoption path.
 - Zero-argument `Text.prepared()` is intentionally unsupported. The package does not introspect native SwiftUI `Text`.
 - Experimental `Text.prepared(source:)` is syntax sugar only: the explicit `source` payload is authoritative, and existing `Text` modifiers are not automatically preserved.
-- `PreparedTextObstacleLayouter` is intentionally narrow: it handles repeated-width prepared text with circular exclusion zones through `PreparedObstacleShape.circle`. It is not a generalized obstacle or magazine-style flow layout engine.
+- `PreparedTextObstacleLayouter` is intentionally narrow: it handles repeated-width prepared text with circle and rounded-rect exclusion zones through `PreparedObstacleShape`. It is not a generalized obstacle or magazine-style flow layout engine.
 
 ## Cache And Runtime Limits
 
 - Stage 0 and Stage 1 caches are bounded and trimmed for UIKit memory pressure, but they are tuned for read-mostly UI, not document editors.
 - Performance claims are scoped to repeated-width read-only sizing workloads. Always benchmark inside the adopting app.
-- Attachment identity, placeholder metrics, and resolved metrics now participate in prepared layout reuse, but the repository still does not ship a full async attachment loader / placeholder renderer pipeline or remote media stack.
-- `PreparedTextSourceCoordinateMap` now powers public visible token / annotation / attachment queries, but it is still not a full editor coordinate model and can fall back to best-effort mapping when whitespace normalization changes source/display correspondence.
+- Attachment identity, placeholder metrics, and resolved metrics now participate in prepared layout reuse through `PreparedAttachmentResolver`, but the repository still does not ship a full async attachment loader / placeholder renderer pipeline or remote media stack.
+- `PreparedTextSourceCoordinateMap` now powers public visible token / annotation / attachment queries and rect helpers, but it is still not a full editor coordinate model and can fall back to best-effort mapping when whitespace normalization changes source/display correspondence.
 - Signpost instrumentation exists for hot paths, but it is still lightweight profiling support rather than a complete tracing product.
 - The demo app and showcase surfaces are verification tools for release readiness; they are not a second product surface.
 - The public line-break strategy surface is intentionally narrow. It offers stable selection among supported heuristics, not generalized browser-grade typography control.

--- a/docs/ReleaseChecklist.md
+++ b/docs/ReleaseChecklist.md
@@ -30,18 +30,20 @@ swift run PretextBenchmarks
   - the stable host gate corpus must keep exact line counts, no divergent strict lines, and `heightDelta <= 1pt`
   - core-owned finite-line / truncation / layout-direction semantic checks must stay green
   - 1-line truncation, URL-heavy finite-line, and Korean finite-line semantic checks must stay green
-  - attachment placeholder/resolved-state, truncation-visible token filtering, and coordinate-map best-effort semantics must stay green
-  - obstacle-layout public structure checks must stay green on supported host/tooling builds
+  - attachment placeholder/resolved-state, attachment-scoped invalidation, truncation-visible token filtering, and coordinate-map best-effort semantics must stay green
+  - coordinate-map rect-query checks for visible link geometry must stay green
+  - obstacle-layout public structure checks, including rounded-rect exclusion, must stay green on supported host/tooling builds
 - `swift run PretextBenchmarks`
   - `.build/reports/benchmark-results.md` must regenerate and be non-empty
   - release review should use the default benchmark sample counts, not a reduced local smoke profile
   - review exact vs `bucketed-4pt` vs `pixel-aligned` policy rows rather than only single cold timings
   - review finite-line and URL strategy rows because Phase 2 moved that policy into the core engine
   - review prepared representation extraction and obstacle-layout rows because Phase 3 promotes them into public differentiators
+  - review attachment-inline rows and obstacle shape rows because Round 1 turns attachment lifecycle and narrow obstacle generalization into documented public features
 - `./scripts/run-ios-demo-tests.sh`
   - the committed iOS demo project at `Apps/PreparedTextDemo/PreparedTextDemo.xcodeproj` must build and test on simulator
   - strict `UILabel` / `UITextView` baseline XCTest must pass for the supported simulator baseline subset
-  - promoted Stage 1 layout options, source-coordinate mapping, token / annotation helpers, attachment helpers, and public obstacle layouter tests must stay green
+  - promoted Stage 1 layout options, source-coordinate mapping, token / annotation helpers, per-link accessibility elements, attachment helpers, and public obstacle layouter tests must stay green
 
 ## Manual Review Before Tagging
 

--- a/docs/Validation.md
+++ b/docs/Validation.md
@@ -11,6 +11,7 @@ The current host coverage locks down the stable Phase 1 to Phase 3 release story
 - public line-break strategy selection on supported narrow surfaces
 - prepared token / annotation visibility through truncation-aware coordinate mapping
 - explicit exact-vs-best-effort source/display mapping semantics
+- coordinate-map rect queries that feed public link geometry and debug/inspection helpers
 - public obstacle-layout helpers over prepared text on supported host/tooling builds
 
 ## Host report
@@ -45,7 +46,9 @@ Phase 3 semantic checks also run in the host validation path:
 - `attachment-spans-report-placeholder-vs-resolved-state`
 - `visible-tokens-follow-truncated-coordinate-map`
 - `coordinate-map-best-effort-mode-is-explicit`
+- `coordinate-map-rect-queries-follow-visible-link-geometry`
 - `obstacle-layout-exposes-public-visible-structure`
+- `rounded-rect-obstacle-layout-exposes-public-visible-structure`
 
 ## Host gate
 
@@ -113,6 +116,7 @@ The simulator baseline subset is intentionally narrower than the host stable cor
 The simulator XCTest path also keeps the promoted UIKit-facing Phase 3 consumers honest:
 
 - `PreparedLabelView` visible token / annotation / attachment helpers
+- `PreparedLabelView` per-link accessibility elements for multi-link visible content, with safe fallback to container-level actions
 - `PreparedTextObstacleLayouter` public result, coordinate-map, and visible-token helpers
 - demo-backed read-only attachment and structured-span samples
 


### PR DESCRIPTION
## Summary

This PR turns the first Round 1 roadmap slice into a coherent public prepared-representation upgrade for `prepared-text-ios`.
It promotes multi-link accessibility in `PreparedLabelView`, adds an explicit attachment resolver lifecycle with targeted invalidation, turns `PreparedTextSourceCoordinateMap` into a practical rect/query surface, and generalizes obstacle-aware layout from circle-only exclusion to a narrow circle/rounded-rect public API.
The result stays within the repository's existing product scope: read-only prepared text, repeated-width sizing, UIKit-first rendering, and SwiftUI bridging.

## Changes

- Promoted multi-link accessibility from container-level custom actions to per-link accessibility elements in [PreparedLabelView.swift](/Users/ijuhwa/Documents/prepared-text-ios/Sources/PretextUIKit/Stage1/PreparedLabelView.swift).
  - `PreparedLabelView` now keeps the view as the accessibility container and creates one summary element plus one focusable link element per visible link when stable link rects can be derived.
  - visible link geometry now comes from `PreparedTextSourceCoordinateMap` + visible annotations instead of ad hoc attributed-string scans.
  - single-link and non-separable cases still fall back safely to the existing accessibility custom action path.
  - truncation and visible-range semantics are respected because the visible-link set is filtered through the prepared packet/source-coordinate map.
- Added an explicit attachment lifecycle surface in [PreparedTextAttachments.swift](/Users/ijuhwa/Documents/prepared-text-ios/Sources/PretextCore/System/PreparedTextAttachments.swift).
  - introduced `PreparedAttachmentLifecycleState` with `.placeholder` and `.resolved` states.
  - introduced `PreparedAttachmentResolver` on top of the existing resolving story so the public API can express placeholder vs resolved lifecycle directly.
  - `PreparedAttachmentRegistry` now conforms to `PreparedAttachmentResolver` and exposes `attachmentState(for:)`, `setAttachmentState(_:invalidate:)`, `removeResolvedAttachment(for:invalidate:)`, `recordedSourceIDs(for:)`, and `invalidateRecordedSources(for:reason:)`.
  - this keeps attachment support read-only and renderer-facing while making placeholder -> resolved relayout and attachment-scoped invalidation a practical public path.
- Strengthened prepared/source/display geometry in [PreparedTextDisplayLayout.swift](/Users/ijuhwa/Documents/prepared-text-ios/Sources/PretextCore/Engine/PreparedTextDisplayLayout.swift) and [PreparedTextTypes.swift](/Users/ijuhwa/Documents/prepared-text-ios/Sources/PretextCore/Engine/PreparedTextTypes.swift).
  - added `PreparedTextDisplayedRect`.
  - added `displayRect` and `isExact` to displayed spans.
  - added `displayFrame` to source-coordinate lines.
  - added public helpers for `displayedLineFrame(at:)`, `sourceUTF16Ranges(onDisplayedLine:)`, `displayedRects(forSourceUTF16Range:)`, `displayedRects(forSourceUTF16Range:onLine:)`, and token/annotation/attachment-span rect queries.
  - packet-local coordinate maps now preserve geometry and expose visible rects, not just range translations.
  - exact mappings are now sliced at composed-character boundaries when source/display space is preserved, so visible rect helpers are useful for per-link accessibility and inspection.
- Generalized obstacle-aware layout in [PreparedTextObstacleLayout.swift](/Users/ijuhwa/Documents/prepared-text-ios/Sources/PretextUIKit/Stage1/PreparedTextObstacleLayout.swift).
  - added `PreparedTextObstacleRoundedRect`.
  - extended `PreparedObstacleShape` with `.roundedRect` while preserving `.circle`.
  - extended `PreparedObstacle` with `init(roundedRect:)` and `roundedRect` accessors.
  - obstacle exclusion intervals now support rounded rectangles with corner falloff while preserving the narrow deterministic row-band model.
  - obstacle layout results continue to expose prepared tokens/annotations/attachment spans and now generate more practical source-coordinate spans for obstacle rows as well.
- Wired the new lifecycle through the system layer.
  - [PreparedTextEngine.swift](/Users/ijuhwa/Documents/prepared-text-ios/Sources/PretextCore/Engine/PreparedTextEngine.swift) and [PreparedTextSystem.swift](/Users/ijuhwa/Documents/prepared-text-ios/Sources/PretextCore/System/PreparedTextSystem.swift) now accept `PreparedAttachmentResolver` so resolver lifecycle participates in the normal prepare/layout pipeline.
- Expanded UIKit demo coverage in [PreparedTextUIKitExamples.swift](/Users/ijuhwa/Documents/prepared-text-ios/Sources/PretextUIKit/Demo/PreparedTextUIKitExamples.swift).
  - the prepared-structure sample now includes two visible links, an attachment resolved through the registry, and notes that call out per-link accessibility and visible-range geometry.
- Added focused test coverage.
  - [PretextCoreTests.swift](/Users/ijuhwa/Documents/prepared-text-ios/Tests/PretextCoreTests/PretextCoreTests.swift) now covers attachment resolver lifecycle, targeted invalidation, visible rect queries for annotations/tokens, and best-effort coordinate-map caveats.
  - [PreparedTextUIKitTests.swift](/Users/ijuhwa/Documents/prepared-text-ios/Tests/PretextUIKitTests/PreparedTextUIKitTests.swift) now covers multi-link accessibility elements, safe fallback behavior, rounded-rect obstacle layout, obstacle coordinate-map rect queries, and updated truncated-coordinate expectations.
- Expanded validation and benchmark coverage.
  - [main.swift](/Users/ijuhwa/Documents/prepared-text-ios/Sources/PretextValidation/main.swift) now validates attachment placeholder/resolved state, visible-link rect queries, obstacle-layout public structure, and rounded-rect obstacle layout.
  - [main.swift](/Users/ijuhwa/Documents/prepared-text-ios/Sources/PretextBenchmarks/main.swift) now reports attachment-bearing rows, coordinate-map extraction work, and circle vs rounded-rect obstacle sweeps.
- Updated docs so the public claims match the implementation.
  - [README.md](/Users/ijuhwa/Documents/prepared-text-ios/README.md) and [README.ko.md](/Users/ijuhwa/Documents/prepared-text-ios/README.ko.md) now describe `PreparedAttachmentResolver`, per-link accessibility, rect/query helpers, and the rounded-rect obstacle path as narrow differentiators.
  - [docs/KnownGaps.md](/Users/ijuhwa/Documents/prepared-text-ios/docs/KnownGaps.md), [docs/Validation.md](/Users/ijuhwa/Documents/prepared-text-ios/docs/Validation.md), [docs/Benchmarks.md](/Users/ijuhwa/Documents/prepared-text-ios/docs/Benchmarks.md), [docs/ReleaseChecklist.md](/Users/ijuhwa/Documents/prepared-text-ios/docs/ReleaseChecklist.md), and [Apps/PreparedTextDemo/README.md](/Users/ijuhwa/Documents/prepared-text-ios/Apps/PreparedTextDemo/README.md) now reflect the actual public surface and its remaining narrow limits.

## Testing

- `source scripts/use-local-xcode.sh && swift test`
  - PASS (`65` tests)
- `source scripts/use-local-xcode.sh && ./scripts/run-validation.sh`
  - PASS
- `source scripts/use-local-xcode.sh && ./scripts/run-validation-gate.sh`
  - PASS
- `source scripts/use-local-xcode.sh && ./scripts/run-benchmarks.sh`
  - PASS
- `source scripts/use-local-xcode.sh && ./scripts/run-ios-demo-tests.sh`
  - PASS (`50` iOS simulator tests)
- `./scripts/check-repo-readiness.sh`
  - PASS
- `npx --yes --package whylog@0.4.0 whylog validate --range origin/main..HEAD --skip-unstructured --strict`
  - PASS
- `./scripts/check-pr.sh --title "feat(prepared): add link accessibility, attachment lifecycle, and rect helpers" --body-file /tmp/prepared-text-ios-round1-pr.md`
  - PASS

## Risks and follow-ups

- `PreparedLabelView` only promotes multiple links to separate accessibility elements when the prepared coordinate map can supply stable visible rects. It intentionally falls back to container-level custom actions otherwise.
- Attachment support is still deliberately narrow: this PR does not introduce remote loading, authoring, or a generic media framework.
- Obstacle-aware layout remains a narrow repeated-width exclusion feature. This PR adds rounded-rect support, but it does not move the product toward arbitrary publication layout.
- The demo still uses the shared attachment registry to seed a resolved sample attachment. That is acceptable for release verification, but it can be isolated further later if maintainers want less global demo setup.

## Related issues

Closes #10
Closes #11
Closes #12
Closes #13
